### PR TITLE
Export Coordinate Fixes (Issues 119 and 113)

### DIFF
--- a/src/components/exporting/ExportCoordinatesModal.tsx
+++ b/src/components/exporting/ExportCoordinatesModal.tsx
@@ -14,6 +14,7 @@ function ExportModalContents() {
     const [includeMeasures, setIncludeMeasures] = useState(true);
     const [useXY, setUseXY] = useState(false);
     const [roundingDenominator, setRoundingDenominator] = useState(4);
+    const [fontSize, setFontSize] = useState(18);
     const { marchers } = useMarcherStore()!;
     const { pages } = usePageStore()!;
     const { marcherPages } = useMarcherPageStore()!;
@@ -31,7 +32,7 @@ function ExportModalContents() {
             coordinateSheets.push(ReactDOMServer.renderToString(
                 <StaticMarcherCoordinateSheet marcher={marcher} pages={pages} marcherPages={marcherPages}
                     includeMeasures={includeMeasures} terse={isTerse} useXY={useXY} fieldProperties={fieldProperties}
-                    roundingDenominator={roundingDenominator}
+                    roundingDenominator={roundingDenominator} fontSize={fontSize}
                 />)
             );
         });
@@ -39,7 +40,7 @@ function ExportModalContents() {
         window.electron.sendExportIndividualCoordinateSheets(coordinateSheets).then(
             () => setIsLoading(false)
         );
-    }, [fieldProperties, marchers, pages, marcherPages, includeMeasures, isTerse, useXY, roundingDenominator]);
+    }, [fieldProperties, marchers, pages, marcherPages, includeMeasures, isTerse, useXY, roundingDenominator, fontSize]);
 
     return (
         <div>
@@ -66,8 +67,13 @@ function ExportModalContents() {
                                             onChange={(e) => setRoundingDenominator(parseInt(e.target.value) || 4)} />
                                     </Col>
                                     <Form.Text className="text-muted">
-                                        {'4 -> 1/4 = nearest quarter step'}<br />{'10 -> 1/10 = nearest tenth step'}
+                                        {'4 -> 1/4 = nearest quarter step'}<br />{'10 -> 1/10 = nearest tenth step'}<br />
                                     </Form.Text>
+                                    <Form.Label>Font Size:</Form.Label>
+                                    <Col sm={3}>
+                                        <Form.Control type="number" defaultValue={fontSize} step={1} min={8} max={40}
+                                            onChange={(e) => setFontSize(parseInt(e.target.value) || 18)} />
+                                    </Col>
                                 </Col>
                             </Row>
                         </Form.Group>
@@ -81,6 +87,7 @@ function ExportModalContents() {
                     <MarcherCoordinateSheet example={true} terse={isTerse}
                         includeMeasures={includeMeasures} useXY={useXY}
                         roundingDenominator={roundingDenominator || 4}
+                        fontSize={fontSize || 18}
                     />
                 </Col>
             </Row>

--- a/src/components/exporting/MarcherCoordinateSheet.tsx
+++ b/src/components/exporting/MarcherCoordinateSheet.tsx
@@ -17,6 +17,7 @@ interface MarcherCoordinateSheetProps {
      * The denominator to round to. 4 -> 1/4 = nearest quarter step. 10 -> 1/10 = nearest tenth step.
      */
     roundingDenominator?: number;
+    fontSize?: number;
     /**
      * Whether this is a printing preview or an example for the user to see.
      */
@@ -37,7 +38,7 @@ interface MarcherCoordinateSheetProps {
 }
 
 export default function MarcherCoordinateSheet(
-    { marcher, includeMeasures = true, roundingDenominator = 4,
+    { marcher, includeMeasures = true, roundingDenominator = 4, fontSize = 12, 
         example = false, terse = false, useXY = false }: MarcherCoordinateSheetProps) {
     const { marcherPages } = useMarcherPageStore()!;
     const { pages } = usePageStore()!;
@@ -97,7 +98,7 @@ export default function MarcherCoordinateSheet(
     return (
         <StaticMarcherCoordinateSheet marcher={marcherToUse!} pages={pagesToUse} marcherPages={marcherPagesToUse}
             fieldProperties={fieldProperties!} includeMeasures={includeMeasures} roundingDenominator={roundingDenominator}
-            terse={terse} useXY={useXY} />
+            fontSize = {fontSize} terse={terse} useXY={useXY} />
     );
 }
 
@@ -111,6 +112,7 @@ interface StaticCoordinateSheetProps {
      * The denominator to round to. 4 -> 1/4 = nearest quarter step. 10 -> 1/10 = nearest tenth step.
      */
     roundingDenominator?: number;
+    fontSize?: number;
     /**
      * True if the coordinate strings should be terse. False if they should be verbose.
      * Default is false.
@@ -127,7 +129,7 @@ interface StaticCoordinateSheetProps {
 }
 
 export function StaticMarcherCoordinateSheet({
-    marcher, fieldProperties, marcherPages, pages, includeMeasures = true, roundingDenominator = 4,
+    marcher, fieldProperties, marcherPages, pages, includeMeasures = true, roundingDenominator = 4, fontSize =12,
     terse = false, useXY = false }: StaticCoordinateSheetProps) {
 
     const sortMarcherPages = (a: MarcherPage, b: MarcherPage) => {
@@ -166,7 +168,7 @@ export function StaticMarcherCoordinateSheet({
                         </Col>
                     </Row>
                     <Row>
-                        <Table striped bordered size="sm">
+                        <Table striped bordered size="sm" style={{ fontSize: fontSize }}>
                             <thead>
                                 <tr aria-label='coordinates header row'>
                                     <th className="text-center" aria-label='page header'>

--- a/src/components/exporting/MarcherCoordinateSheet.tsx
+++ b/src/components/exporting/MarcherCoordinateSheet.tsx
@@ -155,13 +155,13 @@ export function StaticMarcherCoordinateSheet({
                 :
                 <>
                     <Row style={{ backgroundColor: '#ddd' }} aria-label="marcher header">
-                        <Col sm={2} style={headingStyle}>
+                        <Col xs= {2} sm={2} style={headingStyle}>
                             <h2 aria-label='marcher drill number'>{marcher.drill_number}</h2>
                         </Col>
-                        <Col sm={5} style={{ ...headingStyle, borderLeft: "1px solid #888", }}>
+                        <Col xs= {5} sm={5} style={{ ...headingStyle, borderLeft: "1px solid #888", }}>
                             <h4 aria-label='marcher name'>{marcher.name}</h4>
                         </Col>
-                        <Col sm={5} style={{ ...headingStyle, borderLeft: "1px solid #888", }}>
+                        <Col xs= {5} sm={5} style={{ ...headingStyle, borderLeft: "1px solid #888", }}>
                             <h4 aria-label='marcher section'>{marcher.section}</h4>
                         </Col>
                     </Row>

--- a/src/components/exporting/MarcherCoordinateSheet.tsx
+++ b/src/components/exporting/MarcherCoordinateSheet.tsx
@@ -161,10 +161,10 @@ export function StaticMarcherCoordinateSheet({
                             <h2 aria-label='marcher drill number'>{marcher.drill_number}</h2>
                         </Col>
                         <Col xs= {5} sm={5} style={{ ...headingStyle, borderLeft: "1px solid #888", }}>
-                            <h4 aria-label='marcher name'>{marcher.name}</h4>
+                            <h3 aria-label='marcher name'>{marcher.name}</h3>
                         </Col>
                         <Col xs= {5} sm={5} style={{ ...headingStyle, borderLeft: "1px solid #888", }}>
-                            <h4 aria-label='marcher section'>{marcher.section}</h4>
+                            <h3 aria-label='marcher section'>{marcher.section}</h3>
                         </Col>
                     </Row>
                     <Row>


### PR DESCRIPTION
Fixed pdf mismatch issues
     -Gave headers xs class that applies when the page is rendered as pdf
 Adding in the feature to change the font size in the preview and  the PDF 
     -Added Form for font size
     -Added Parameters for font size in the static and nonstatic MarcherCoordinateSheets
Changed the Header type because I thought it looked better.