### PR TITLE
🔧 Page extends past last measure

### DIFF
--- a/src/components/timeline/TimelineContainer.tsx
+++ b/src/components/timeline/TimelineContainer.tsx
@@ -17,7 +17,10 @@ export default function TimelineContainer({
 
     // Rerender the timeline when the measures or pages change
     React.useEffect(() => {
-        // do nothing, just rerender
+        console.log("measures or pages changed");
+        console.log("measures", measures);
+        console.log("pages", pages);
+        // do nothing, just re-render
     }, [measures, pages]);
 
     return (
@@ -67,6 +70,7 @@ export default function TimelineContainer({
                     )}
                     <div className="row-span-2">
                         {pages.map((page, index) => {
+                            if (page.name === "8") console.log("page 8", page);
                             if (index === 0) return null;
                             const width = page.duration * pxPerSecond;
                             // console.log("page width", width)

--- a/src/global/classes/Page.ts
+++ b/src/global/classes/Page.ts
@@ -404,13 +404,18 @@ class Page {
                 outputPages[currentPageIndex]._measures.push(currentMeasure);
                 // Add the offset of the current measure beat
                 const offsetBigBeats = currentMeasure.getBigBeats() - currentMeasureBeat + 1;
-                if (remainingCounts - offsetBigBeats >= 0) {
-                    // there are enough remaining counts in the page to complete the measure
-                    outputPages[currentPageIndex]._duration += (offsetBigBeats / currentMeasure.getBigBeats()) * currentMeasure.duration;
-                    currentMeasureIndex++;
-                    currentMeasureBeat = 1;
-                } else {
-                    // there are not enough counts in the page to complete the measure. Add the remaining counts to the duration
+                if (remainingCounts - offsetBigBeats >= 0) { // there are enough remaining counts in the page to complete the measure
+                    if (currentMeasureIndex === measures.length - 1) { // last measure
+                        const durationPerBeat = currentMeasure.duration / currentMeasure.getBigBeats();
+                        outputPages[currentPageIndex]._duration += durationPerBeat * remainingCounts;
+                        break;
+
+                    } else { // not the last measure, fill the page with beats from the measures
+                        outputPages[currentPageIndex]._duration += (offsetBigBeats / currentMeasure.getBigBeats()) * currentMeasure.duration;
+                        currentMeasureIndex++;
+                        currentMeasureBeat = 1;
+                    }
+                } else { // there are not enough counts in the page to complete the measure. Add the remaining counts to the duration
                     outputPages[currentPageIndex]._duration += (remainingCounts / currentMeasure.getBigBeats()) * currentMeasure.duration;
                     currentMeasureBeat = remainingCounts + 1;
                     break;

--- a/src/global/classes/__test__/Page.test.ts
+++ b/src/global/classes/__test__/Page.test.ts
@@ -713,10 +713,10 @@ describe('Page', () => {
             expect(alignedPages.length).toBe(pages.length);
 
             // Check the duration of each page
-            expect(alignedPages[0].duration).toBe(0); // 16 counts * 500 ms per count = 4 seconds
-            expect(alignedPages[1].duration).toBe(4); // 16 counts * 500 ms per count = 4 seconds
-            expect(alignedPages[2].duration).toBe(2); // 8 counts * 500 ms per count = 2 seconds
-            expect(alignedPages[3].duration).toBe(2); // 32 counts * 500 ms per count = 8 seconds
+            expect(alignedPages[0].duration).toBe(0);
+            expect(alignedPages[1].duration).toBe(4); // 8 counts * 500 ms per count = 4 seconds
+            expect(alignedPages[2].duration).toBe(2); // 4 counts * 500 ms per count = 2 seconds
+            expect(alignedPages[3].duration).toBe(2); // 4 counts * 500 ms per count = 2 seconds
 
             // Check that the timestamps are inserted correctly
             expect(alignedPages[0].timestamp).toEqual(0);
@@ -756,9 +756,9 @@ describe('Page', () => {
             expect(alignedPages.length).toBe(pages.length);
 
             // Check the duration of each page
-            expect(alignedPages[0].duration).toBe(0); // 6 counts * 500 ms per count = 3 seconds
-            expect(alignedPages[1].duration).toBe(3); // 3 counts * 500 ms per count = 1.5 seconds
-            expect(alignedPages[2].duration).toBe(1.5); // 7 counts * 500 ms per count = 3.5 seconds
+            expect(alignedPages[0].duration).toBe(0);
+            expect(alignedPages[1].duration).toBe(3); // 6 counts * 500 ms per count = 3 seconds
+            expect(alignedPages[2].duration).toBe(1.5); // 3 counts * 500 ms per count = 1.5 seconds
             expect(alignedPages[3].duration).toBe(3.5); // 7 counts * 500 ms per count = 3.5 seconds
 
             // Check that the timestamps are inserted correctly
@@ -780,5 +780,48 @@ describe('Page', () => {
             expect(alignedPages[2].measureBeatToStartOn).toBe(3);
             expect(alignedPages[3].measureBeatToStartOn).toBe(2);
         });
+
+        it('When the last page goes beyond the last measure, adjust so that it assumes it stays the same tempo', () => {
+            const measures = [
+                new Measure({ number: 1, timeSignature: TimeSignature.fromString('4/4'), tempo: 120, beatUnit: BeatUnit.QUARTER }),
+                new Measure({ number: 2, timeSignature: TimeSignature.fromString('4/4'), tempo: 120, beatUnit: BeatUnit.QUARTER }),
+                new Measure({ number: 3, timeSignature: TimeSignature.fromString('4/4'), tempo: 120, beatUnit: BeatUnit.QUARTER }),
+                new Measure({ number: 3, timeSignature: TimeSignature.fromString('4/4'), tempo: 120, beatUnit: BeatUnit.QUARTER }),
+            ]
+            const pages = [
+                new Page({ id: 0, id_for_html: 'page_0', name: '0', counts: 0, order: 0 }),
+                new Page({ id: 1, id_for_html: 'page_1', name: '1', counts: 8, order: 1 }),
+                new Page({ id: 2, id_for_html: 'page_2', name: '2', counts: 4, order: 2 }),
+                new Page({ id: 3, id_for_html: 'page_3', name: '3', counts: 16, order: 3 }),
+            ];
+            const alignedPages = Page.alignWithMeasures(pages, measures);
+
+            expect(alignedPages.length).toBe(pages.length);
+
+            // Check the duration of each page
+            expect(alignedPages[0].duration).toBe(0);
+            expect(alignedPages[1].duration).toBe(4); // 16 counts * 500 ms per count = 4 seconds
+            expect(alignedPages[2].duration).toBe(2); // 8 counts * 500 ms per count = 2 seconds
+            expect(alignedPages[3].duration).toBe(8); // 16 counts * 500 ms per count = 8 seconds
+
+            // Check that the timestamps are inserted correctly
+            expect(alignedPages[0].timestamp).toEqual(0);
+            expect(alignedPages[1].timestamp).toEqual(4);
+            expect(alignedPages[2].timestamp).toEqual(6);
+            expect(alignedPages[3].timestamp).toEqual(14);
+
+            // Check that the measures are inserted correctly
+            expect(alignedPages[0].measures).toEqual([]);
+            expect(alignedPages[1].measures).toEqual([measures[0], measures[1]]);
+            expect(alignedPages[2].measures).toEqual([measures[2]]);
+            expect(alignedPages[3].measures).toEqual([measures[3]]);
+
+            // expect all measure beats to be 1 (as in the first beat of the measure)
+            expect(alignedPages[0].measureBeatToStartOn).toBe(1);
+            expect(alignedPages[1].measureBeatToStartOn).toBe(1);
+            expect(alignedPages[2].measureBeatToStartOn).toBe(1);
+            expect(alignedPages[3].measureBeatToStartOn).toBe(1);
+        });
+
     });
 });


### PR DESCRIPTION
fix #184 - Pages that bring project over 8 measures get set to one measure
The counts were being reported correctly, but the duration of the page was being cut short if it were to extend beyond the last measure