### PR TITLE
Calculate step sizes

### DIFF
--- a/src/global/classes/StepSize.ts
+++ b/src/global/classes/StepSize.ts
@@ -1,0 +1,240 @@
+import FieldProperties from "./FieldProperties";
+import Marcher from "./Marcher";
+import MarcherPage from "./MarcherPage";
+import Page from "./Page";
+
+const INCHES_PER_YARD = 36;
+
+export interface MinMaxStepSizes {
+    min: StepSize | undefined;
+    max: StepSize | undefined;
+}
+
+export class StepSize {
+    /* ----------- Attributes ----------- */
+
+    /** Steps needed to cover five yards, for example 8 for 8 to 5 */
+    readonly stepsPerFiveYards: number;
+    /** Id of the marcher for this step size */
+    readonly marcher_id: number;
+
+    constructor({
+        marcher_id,
+        startingX,
+        startingY,
+        endingX,
+        endingY,
+        counts,
+        fieldProperties,
+    }: {
+        marcher_id: number;
+        startingX: number;
+        startingY: number;
+        endingX: number;
+        endingY: number;
+        counts: number;
+        fieldProperties: FieldProperties;
+    }) {
+        this.marcher_id = marcher_id;
+        this.stepsPerFiveYards = StepSize.calculateStepSize({
+            startingX,
+            startingY,
+            endingX,
+            endingY,
+            counts,
+            pixelsPerStep: fieldProperties.pixelsPerStep,
+        });
+    }
+
+    private static calculateStepSize({
+        startingX,
+        startingY,
+        endingX,
+        endingY,
+        counts,
+        pixelsPerStep,
+    }: {
+        startingX: number;
+        startingY: number;
+        endingX: number;
+        endingY: number;
+        counts: number;
+        pixelsPerStep: number;
+    }) {
+        if (!counts) {
+            return NaN; // don't divide by 0, indicate there is no actual number here
+        }
+
+        // find the horizontal distance across the canvas
+        const xDistance = Math.abs(endingX - startingX);
+        // find the vertical distance across the canvas
+        const yDistance = Math.abs(endingY - startingY);
+        // pythagorean theorem to get the total distance
+        const distanceInPixels = Math.sqrt(xDistance ** 2 + yDistance ** 2);
+
+        if (!distanceInPixels) {
+            return Infinity; // don't divide by 0, indicates a hold
+        }
+
+        // convert to distance in 8 to 5 steps
+        const distanceIn8to5Steps = distanceInPixels / pixelsPerStep;
+        // convert to distance in inches
+        const distanceCoveredInInches = distanceIn8to5Steps * 22.5;
+        // determine the distance in inches per step
+        const distanceInInchesPerStep = distanceCoveredInInches / counts;
+
+        // determine how many steps it would take to traverse 5 yards and round the result
+        return (INCHES_PER_YARD * 5) / distanceInInchesPerStep;
+    }
+
+    /**
+     * Creates a display string for the step size, e.g. "8 to 5" or "6.7 to 5"
+     * @returns display string
+     */
+    displayString() {
+        if (Number.isNaN(this.stepsPerFiveYards)) {
+            return "Undefined"; // when there are 0 counts in the page.
+        }
+
+        if (this.stepsPerFiveYards === Infinity) {
+            return "Hold"; // when the performer hasn't moved at all from the previous page.
+        }
+
+        const roundedSteps = Math.round(this.stepsPerFiveYards * 10) / 10;
+        if (roundedSteps > 64) {
+            return "Tiny"; // show 'Tiny' instead of something crazy like 73,249.7 to 5
+        }
+
+        return `${roundedSteps.toLocaleString()} to 5`;
+    }
+
+    /**
+     * Creates a step size object from a starting and ending marcher page, and the drill page.
+     *
+     * @param startingPage starting coordinate of the move
+     * @param endingPage ending page of the move
+     * @param page represents the move, including number of counts
+     * @param fieldProperties The properties of the performance area
+     * @returns optional StepSize, if defined
+     */
+    static createStepSizeForMarcher({
+        startingPage,
+        endingPage,
+        page,
+        fieldProperties,
+    }: {
+        startingPage?: MarcherPage;
+        endingPage: MarcherPage;
+        page?: Page;
+        fieldProperties: FieldProperties;
+    }) {
+        if (!startingPage || !page) {
+            return undefined;
+        }
+
+        return new StepSize({
+            marcher_id: endingPage.marcher_id,
+            startingX: startingPage.x,
+            startingY: startingPage.y,
+            endingX: endingPage.x,
+            endingY: endingPage.y,
+            counts: page.counts,
+            fieldProperties,
+        });
+    }
+
+    /**
+     * Returns a list of step sizes for the given marchers
+     * @param startingPages the starting coordinates of each marcher
+     * @param endingPages the ending coordinates of each marcher
+     * @param page the page that the marchers are on
+     * @param fieldProperties the properties of the performance area
+     * @returns step size for all given marchers
+     */
+    static createStepSizesForMarchers({
+        marchers,
+        marcherPages,
+        page,
+        fieldProperties,
+    }: {
+        marchers: Marcher[];
+        marcherPages: MarcherPage[];
+        page: Page;
+        fieldProperties: FieldProperties;
+    }) {
+        const startingPages = marcherPages.filter(
+            (marcherPage) => marcherPage.page_id === page.id - 1,
+        );
+        const endingPages = marcherPages.filter(
+            (marcherPage) => marcherPage.page_id === page.id,
+        );
+        return marchers
+            .map((marcher) => {
+                const startingPage = startingPages.find(
+                    (marcherPage) => marcherPage.marcher_id === marcher.id,
+                );
+                const endingPage = endingPages.find(
+                    (marcherPage) => marcherPage.marcher_id === marcher.id,
+                );
+                if (!endingPage) return undefined;
+
+                return StepSize.createStepSizeForMarcher({
+                    startingPage,
+                    endingPage,
+                    page: page,
+                    fieldProperties,
+                });
+            })
+            .filter((stepSize) => stepSize !== undefined); // filter out undefined
+    }
+
+    /**
+     * Returns the smallest and largest step size for the given marchers
+     * @param startingPages the starting coordinates of each marcher
+     * @param endingPages the ending coordinates of each marcher
+     * @param page the page that the marchers are on
+     * @param fieldProperties the properties of the performance area
+     * @returns largest and smallest step size for the given marchers
+     */
+    static getMinAndMaxStepSizesForMarchers({
+        marchers,
+        marcherPages,
+        page,
+        fieldProperties,
+    }: {
+        marchers: Marcher[];
+        marcherPages: MarcherPage[];
+        page: Page;
+        fieldProperties: FieldProperties;
+    }) {
+        const stepSizes = StepSize.createStepSizesForMarchers({
+            marchers,
+            marcherPages,
+            page,
+            fieldProperties,
+        }).sort((o1, o2) => StepSize.compare(o1, o2)); // sort by smallest to largest step size
+
+        if (!stepSizes.length) {
+            return {
+                min: undefined,
+                max: undefined,
+            };
+        }
+
+        return {
+            min: stepSizes[0],
+            max: stepSizes[stepSizes.length - 1],
+        };
+    }
+
+    /**
+     * Compares two step sizes by their steps per five yards. Considers step size to be larger if it is less steps per five yards.
+     * @param a first step size
+     * @param b second step size
+     * @returns > 1 if first is larger, < 1 if second is larger, 0 if equal
+     */
+    static compare(a: StepSize, b: StepSize) {
+        // Smaller number means larger step size
+        return b.stepsPerFiveYards - a.stepsPerFiveYards;
+    }
+}

--- a/src/global/classes/__test__/StepSize.test.ts
+++ b/src/global/classes/__test__/StepSize.test.ts
@@ -1,0 +1,446 @@
+import FieldProperties, { PixelsPerStep } from "../FieldProperties";
+import FieldPropertiesTemplates from "../FieldProperties.templates";
+import Marcher from "../Marcher";
+import MarcherPage from "../MarcherPage";
+import Page from "../Page";
+import { StepSize } from "../StepSize";
+import { describe, expect, it } from "vitest";
+
+describe("StepSize", () => {
+    it("should be able to create a step size object", () => {
+        const stepSize = new StepSize({
+            marcher_id: 1,
+            // on the 50, on the front hash
+            startingX: 960,
+            startingY: 687.96,
+            // on the 50, 8 in front of the front hash
+            endingX: 960,
+            endingY: 783.96,
+            counts: 8,
+            fieldProperties:
+                FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES,
+        });
+
+        expect(stepSize).toBeInstanceOf(StepSize);
+        expect(stepSize.marcher_id).toBe(1);
+        expect(stepSize.displayString()).toBe("8 to 5");
+        expect(stepSize.stepsPerFiveYards).toBe(8);
+    });
+
+    it("should correctly identify a 16 to 5 step size", () => {
+        const stepSize = new StepSize({
+            marcher_id: 2,
+            // on the 50, on the front hash
+            startingX: 960,
+            startingY: 687.96,
+            // Splitting the 45 and 50 on S1, on the front hash
+            endingX: 1008,
+            endingY: 687.96,
+            counts: 8,
+            fieldProperties:
+                FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES,
+        });
+
+        expect(stepSize.displayString()).toBe("16 to 5");
+        expect(stepSize.stepsPerFiveYards).toBe(16);
+    });
+
+    it("should correctly identify a diagonal step size", () => {
+        const stepSize = new StepSize({
+            marcher_id: 3,
+            // on the 50, on the front hash
+            startingX: 960,
+            startingY: 687.96,
+            // Splitting the 45 and 50 on S1, 3 behind the front hash
+            endingX: 1008,
+            endingY: 651.96,
+            counts: 8,
+            fieldProperties:
+                FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES,
+        });
+
+        expect(stepSize.displayString()).toBe("12.8 to 5");
+        expect(stepSize.stepsPerFiveYards).toBe(12.8);
+    });
+
+    it("should correctly handle a 6 to 5 grid", () => {
+        const stepSize = new StepSize({
+            marcher_id: 3,
+            // on the 50, on the front hash
+            startingX: 960,
+            startingY: 687.96,
+            // on the 50, 8 in front of the front hash (in 6 to 5 grid)
+            endingX: 960,
+            endingY: 815.96,
+            counts: 8,
+            fieldProperties: {
+                pixelsPerStep: PixelsPerStep.SIX_TO_FIVE,
+            } as FieldProperties,
+        });
+
+        expect(stepSize.displayString()).toBe("8 to 5");
+        expect(stepSize.stepsPerFiveYards).toBe(8);
+    });
+
+    it("should show 'Tiny' for step sizes smaller than 64 to 5", () => {
+        const stepSize = new StepSize({
+            marcher_id: 3,
+            // on the 50, on the front hash
+            startingX: 960,
+            startingY: 687.96,
+            // one hundredth of a pixel away
+            endingX: 960,
+            endingY: 687.97,
+            counts: 8,
+            fieldProperties:
+                FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES,
+        });
+
+        expect(stepSize.displayString()).toBe("Tiny");
+        expect(stepSize.stepsPerFiveYards).toBe(76800.00000006985);
+    });
+
+    it("should handle when counts are 0", () => {
+        const stepSize = new StepSize({
+            marcher_id: 3,
+            // on the 50, on the front hash
+            startingX: 960,
+            startingY: 687.96,
+            // Splitting the 45 and 50 on S1, 3 behind the front hash
+            endingX: 1008,
+            endingY: 651.96,
+            counts: 0,
+            fieldProperties:
+                FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES,
+        });
+
+        expect(stepSize.displayString()).toBe("Undefined");
+        expect(stepSize.stepsPerFiveYards).toBeNaN();
+    });
+
+    it("should handle when the performer doesn't move", () => {
+        const stepSize = new StepSize({
+            marcher_id: 3,
+            // on the 50, on the front hash
+            startingX: 960,
+            startingY: 687.96,
+            // on the 50, on the front hash
+            endingX: 960,
+            endingY: 687.96,
+            counts: 8,
+            fieldProperties:
+                FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES,
+        });
+
+        expect(stepSize.displayString()).toBe("Hold");
+        expect(stepSize.stepsPerFiveYards).toBe(Infinity);
+    });
+
+    it("should create a step size from start and end marcher page", () => {
+        const startingPage = {
+            marcher_id: 1,
+            // on the 50, on the front hash
+            x: 960,
+            y: 687.96,
+        } as MarcherPage;
+        const endingPage = {
+            marcher_id: 1,
+            // on the 50, 8 in front of the front hash
+            x: 960,
+            y: 783.96,
+        } as MarcherPage;
+        const page = {
+            counts: 16,
+        } as Page;
+        const stepSize = StepSize.createStepSizeForMarcher({
+            startingPage,
+            endingPage,
+            page,
+            fieldProperties:
+                FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES,
+        });
+
+        expect(stepSize).toBeDefined();
+        expect(stepSize!.displayString()).toBe("16 to 5");
+        expect(stepSize!.stepsPerFiveYards).toBe(16);
+    });
+
+    it("should return undefined when starting page is undefined", () => {
+        const endingPage = {
+            marcher_id: 1,
+            // on the 50, 8 in front of the front hash
+            x: 960,
+            y: 783.96,
+        } as MarcherPage;
+        const page = {
+            counts: 16,
+        } as Page;
+        const stepSize = StepSize.createStepSizeForMarcher({
+            startingPage: undefined,
+            endingPage,
+            page,
+            fieldProperties:
+                FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES,
+        });
+
+        expect(stepSize).toBeUndefined();
+    });
+
+    it("should find step sizes for a list of marchers", () => {
+        // selected marchers
+        const marchers = [
+            {
+                id: 1,
+            },
+            {
+                id: 2,
+            },
+            {
+                id: 3,
+            },
+            // dots exist for marcher 4, verify that we don't return those in the list
+        ] as Marcher[];
+        const page = {
+            counts: 8,
+            id: 5,
+            previousPageId: 4,
+        } as Page;
+        const marcherPages = [
+            // Marcher 1 - 8 to 5
+            {
+                marcher_id: 1,
+                x: 960,
+                y: 687.96,
+                page_id: 4,
+            },
+            {
+                marcher_id: 1,
+                x: 960,
+                y: 783.96,
+                page_id: 5,
+            },
+            // Marcher 2 - 16 to 5
+            {
+                marcher_id: 2,
+                x: 960,
+                y: 687.96,
+                page_id: 4,
+            },
+            {
+                marcher_id: 2,
+                x: 1008,
+                y: 687.96,
+                page_id: 5,
+            },
+            // Marcher 3 - 12.8 to 5
+            {
+                marcher_id: 3,
+                x: 960,
+                y: 687.96,
+                page_id: 4,
+            },
+            {
+                marcher_id: 3,
+                x: 1008,
+                y: 651.96,
+                page_id: 5,
+            },
+            // Marcher 4 - 8 to 5
+            {
+                marcher_id: 4,
+                x: 960,
+                y: 687.96,
+                page_id: 4,
+            },
+            {
+                marcher_id: 4,
+                x: 960,
+                y: 783.96,
+                page_id: 5,
+            },
+        ] as MarcherPage[];
+        const stepSizes = StepSize.createStepSizesForMarchers({
+            marchers,
+            marcherPages,
+            page,
+            fieldProperties:
+                FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES,
+        });
+
+        expect(stepSizes).toBeDefined();
+        expect(stepSizes.length).toBe(3);
+
+        const marcher1StepSize = stepSizes.find(
+            (stepSize) => stepSize.marcher_id === 1,
+        );
+        expect(marcher1StepSize).toBeDefined();
+        expect(marcher1StepSize!.displayString()).toBe("8 to 5");
+
+        const marcher2StepSize = stepSizes.find(
+            (stepSize) => stepSize.marcher_id === 2,
+        );
+        expect(marcher2StepSize).toBeDefined();
+        expect(marcher2StepSize!.displayString()).toBe("16 to 5");
+
+        const marcher3StepSize = stepSizes.find(
+            (stepSize) => stepSize.marcher_id === 3,
+        );
+        expect(marcher3StepSize).toBeDefined();
+        expect(marcher3StepSize!.displayString()).toBe("12.8 to 5");
+
+        const marcher4StepSize = stepSizes.find(
+            (stepSize) => stepSize.marcher_id === 4,
+        );
+        expect(marcher4StepSize).toBeUndefined();
+    });
+
+    it("should find min and max step sizes for a list of marchers", () => {
+        // selected marchers
+        const marchers = [
+            {
+                id: 1,
+            },
+            {
+                id: 2,
+            },
+            {
+                id: 3,
+            },
+            // dots exist for marcher 4, verify that we don't return those in the list
+        ] as Marcher[];
+        const page = {
+            counts: 8,
+            id: 5,
+            previousPageId: 4,
+        } as Page;
+        const marcherPages = [
+            // Marcher 1 - 8 to 5
+            {
+                marcher_id: 1,
+                x: 960,
+                y: 687.96,
+                page_id: 4,
+            },
+            {
+                marcher_id: 1,
+                x: 960,
+                y: 783.96,
+                page_id: 5,
+            },
+            // Marcher 2 - 16 to 5
+            {
+                marcher_id: 2,
+                x: 960,
+                y: 687.96,
+                page_id: 4,
+            },
+            {
+                marcher_id: 2,
+                x: 1008,
+                y: 687.96,
+                page_id: 5,
+            },
+            // Marcher 3 - 12.8 to 5
+            {
+                marcher_id: 3,
+                x: 960,
+                y: 687.96,
+                page_id: 4,
+            },
+            {
+                marcher_id: 3,
+                x: 1008,
+                y: 651.96,
+                page_id: 5,
+            },
+            // Marcher 4 - 4 to 5
+            {
+                marcher_id: 4,
+                x: 960,
+                y: 687.96,
+                page_id: 4,
+            },
+            {
+                marcher_id: 4,
+                x: 960,
+                y: 495.96,
+                page_id: 5,
+            },
+        ] as MarcherPage[];
+        const stepSizes = StepSize.getMinAndMaxStepSizesForMarchers({
+            marchers,
+            marcherPages,
+            page,
+            fieldProperties:
+                FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES,
+        });
+
+        expect(stepSizes).toBeDefined();
+        expect(stepSizes.min).toBeDefined();
+        expect(stepSizes.max).toBeDefined();
+
+        expect(stepSizes.min!.stepsPerFiveYards).toBe(16);
+        expect(stepSizes.min!.marcher_id).toBe(2);
+
+        expect(stepSizes.max!.stepsPerFiveYards).toBe(8);
+        expect(stepSizes.max!.marcher_id).toBe(1);
+    });
+
+    it("should handle min and max when there is no previous page", () => {
+        // selected marchers
+        const marchers = [
+            {
+                id: 1,
+            },
+            {
+                id: 2,
+            },
+            {
+                id: 3,
+            },
+            // dots exist for marcher 4, verify that we don't return those in the list
+        ] as Marcher[];
+        const page = {
+            counts: 8,
+            id: 5,
+            previousPageId: 4,
+        } as Page;
+        const marcherPages = [
+            {
+                marcher_id: 1,
+                x: 960,
+                y: 783.96,
+                page_id: 5,
+            },
+            {
+                marcher_id: 2,
+                x: 1008,
+                y: 687.96,
+                page_id: 5,
+            },
+            {
+                marcher_id: 3,
+                x: 1008,
+                y: 651.96,
+                page_id: 5,
+            },
+            {
+                marcher_id: 4,
+                x: 960,
+                y: 495.96,
+                page_id: 5,
+            },
+        ] as MarcherPage[];
+        const stepSizes = StepSize.getMinAndMaxStepSizesForMarchers({
+            marchers,
+            marcherPages,
+            page,
+            fieldProperties:
+                FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES,
+        });
+
+        expect(stepSizes).toBeDefined();
+        expect(stepSizes.min).toBeUndefined();
+        expect(stepSizes.max).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Issue
https://github.com/OpenMarch/OpenMarch/issues/238

## Overview
This PR adds calculated step sizes to the UI. The step sizes have been added to the Marcher/Marchers section of the sidebar. 

When there is one marcher selected, the step size will be shown for that marcher.
<img width="1510" alt="Screenshot 2024-12-07 at 5 01 45 PM" src="https://github.com/user-attachments/assets/5a89ee3c-ccc3-42ed-bd66-6c8a856ce640">

When there are multiple marchers selected, the largest and smallest step size from the selected marchers is shown. 
<img width="1507" alt="Screenshot 2024-12-07 at 6 58 36 PM" src="https://github.com/user-attachments/assets/ea2fb441-7c46-4029-b772-b2af452d98fd">

If there is no previous dot to calculate from, no step size is displayed (UI is unchanged from before)
<img width="1507" alt="Screenshot 2024-12-07 at 5 01 57 PM" src="https://github.com/user-attachments/assets/75afcb97-4345-45f7-9abe-8b29e1675558">

Some additional edge case handling:
- If for some reason you created a set with 0 counts, shows a step size of "Undefined"
- If the marcher doesn't move, shows a step size of ~"Undefined"~ "Hold"
- If the step size is smaller than 64 to 5, shows a step size of "Tiny"

## Implementation
Created a `StepSize` model to represent a step size. Just holds the steps per five yards as a number, and the ID of the marcher. Need the ID of the marcher so the UI can indicate which marcher has the smallest or largest step size when multiple performers are selected. 

Most of the calculation/business logic is in `StepSize.ts` to make testing easier. 

### HDTs

- Open to suggestions for where we want to display this on the UI if the "Marcher" dropdown in the sidebar isn't the right place for this, just took a first stab at it. Also I wasn't quite sure where to put it in the list within the Marcher dropdown. It felt best by the X/Y coords, but could make an argument to put it basically anywhere here. Happy to move it around. 
- The model class is a little big. Not really bloated but it does include some display logic. I might normally look for something like a presenter object to handle how the UI would display a step size, but doesn't seem like that's how other things are organized. Happy to refactor we don't want display logic in the model. 

## Testing and Verification
- Manual testing
- `npm run test src/global/classes/__test__/StepSize.test.ts`
   
```
 ✓ src/global/classes/__test__/StepSize.test.ts (12)
   ✓ StepSize (12)
     ✓ should be able to create a step size object
     ✓ should correctly identify a 16 to 5 step size
     ✓ should correctly identify a diagonal step size
     ✓ should correctly handle a 6 to 5 grid
     ✓ should show 'Tiny' for step sizes smaller than 64 to 5
     ✓ should handle when counts are 0
     ✓ should handle when the performer doesn't move
     ✓ should create a step size from start and end marcher page
     ✓ should return undefined when starting page is undefined
     ✓ should find step sizes for a list of marchers
     ✓ should find min and max step sizes for a list of marchers
     ✓ should handle min and max when there is no previous page

 Test Files  1 passed (1)
      Tests  12 passed (12)
```
      