### PR TITLE
basic marcher spread out for easier selection

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,7 +22,7 @@ module.exports = {
         "max-lines-per-function": [
             "warn",
             {
-                max: 70,
+                max: 80,
                 skipBlankLines: true,
                 skipComments: true,
             },

--- a/electron/database/tables/MarcherTable.ts
+++ b/electron/database/tables/MarcherTable.ts
@@ -73,12 +73,12 @@ export function createMarchers({
         }
         // Create a marcherPage for each marcher
         const newMarcherPages: ModifiedMarcherPageArgs[] = [];
-        for (const marcher of marcherInsertResponse.data) {
+        for (const [index, marcher] of marcherInsertResponse.data.entries()) {
             for (const page of allPages.data) {
                 newMarcherPages.push({
                     marcher_id: marcher.id,
                     page_id: page.id,
-                    x: 100,
+                    x: 100 + index * 20,
                     y: 100,
                 });
             }

--- a/electron/database/tables/__test__/MarcherTable.test.ts
+++ b/electron/database/tables/__test__/MarcherTable.test.ts
@@ -253,6 +253,54 @@ describe("MarcherTable", () => {
                 }
                 expect(marcherPagesMap.size).toBe(5);
             });
+            it("should create marchers with correct initial positions", () => {
+                const newMarchers: NewMarcherArgs[] = [
+                    {
+                        name: "Test Marcher 1",
+                        section: "Brass",
+                        year: "Senior",
+                        drill_prefix: "T",
+                        drill_order: 1,
+                    },
+                    {
+                        name: "Test Marcher 2",
+                        section: "Woodwind",
+                        year: "Junior",
+                        drill_prefix: "W",
+                        drill_order: 2,
+                    },
+                ];
+
+                const createMarchersResponse = MarcherTable.createMarchers({
+                    newMarchers,
+                    db,
+                });
+                expect(createMarchersResponse.success).toBe(true);
+                expect(createMarchersResponse.data.length).toBe(2);
+
+                const marcherPages = MarcherPageTable.getMarcherPages({
+                    db,
+                });
+                expect(marcherPages.success).toBe(true);
+
+                const marcher1Pages = marcherPages.data.filter(
+                    (mp) => mp.marcher_id === createMarchersResponse.data[0].id,
+                );
+                expect(marcher1Pages.length).toBe(1);
+                marcher1Pages.forEach((mp) => {
+                    expect(mp.x).toBe(100); // First marcher at x=100
+                    expect(mp.y).toBe(100);
+                });
+
+                const marcher2Pages = marcherPages.data.filter(
+                    (mp) => mp.marcher_id === createMarchersResponse.data[1].id,
+                );
+                expect(marcher2Pages.length).toBe(1);
+                marcher2Pages.forEach((mp) => {
+                    expect(mp.x).toBe(120); // Second marcher at x=120 (100 + 20)
+                    expect(mp.y).toBe(100);
+                });
+            });
         });
 
         describe("updateMarchers", () => {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "scripts": {
         "dev": "vite",
-        "app:prepare": "node_modules/.bin/electron-rebuild -f -w better-sqlite3 && vite",
+        "app:prepare": "npx electron-rebuild -f -w better-sqlite3 && vite",
         "build": "tsc && vite build",
         "clean": "rm -rf node_modules dist-electron release",
         "lint": "eslint . --max-warnings 0",


### PR DESCRIPTION
This PR spreads out marchers when adding multiple. This way you can select them more easily.

<img width="815" alt="Screenshot 2025-05-05 210251" src="https://github.com/user-attachments/assets/b07aa151-3fea-4df5-a558-a6a1bcd5d27a" />

I also added a test and had to make a couple of unrelated changes 
- one to adjust the max lines eslint rule (imo this rule has dubious value)
- another to use npx for app:prepare so it would work on windows too