### PR TITLE
Implement a basic plugin system + Make canvas a part of window

### DIFF
--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -309,6 +309,20 @@ ipcMain.handle("get:showWaveform", async () => {
     return store.get("showWaveform", true);
 });
 
+// Plugins
+ipcMain.handle("plugins:list", async () => {
+    const pluginsDir = join(app.getPath("userData"), "plugins");
+    if (!fs.existsSync(pluginsDir)) return [];
+    return fs
+        .readdirSync(pluginsDir)
+        .filter((file) => file.endsWith(".om.js"))
+        .map((file) => join(pluginsDir, file));
+});
+
+ipcMain.handle("plugins:get", async (_, pluginPath) => {
+    return fs.readFileSync(pluginPath, "utf-8");
+});
+
 app.on("second-instance", () => {
     if (win) {
         // Focus on the main window if the user tried to open another

--- a/apps/desktop/electron/preload/index.ts
+++ b/apps/desktop/electron/preload/index.ts
@@ -513,4 +513,13 @@ const APP_API = {
 
 contextBridge.exposeInMainWorld("electron", APP_API);
 
+const PLUGINS_API = {
+    list: () => ipcRenderer.invoke("plugins:list") as Promise<string[]>,
+    get: (pluginPath: string) =>
+        ipcRenderer.invoke("plugins:get", pluginPath) as Promise<string>,
+};
+
+contextBridge.exposeInMainWorld("plugins", PLUGINS_API);
+
 export type ElectronApi = typeof APP_API;
+export type PluginsApi = typeof PLUGINS_API;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -57,30 +57,6 @@ function App() {
     }, []);
 
     useEffect(() => {
-        console.log("Loading plugins...");
-        window.plugins?.list().then(async (pluginPaths: string[]) => {
-            for (const path of pluginPaths) {
-                try {
-                    const code = await window.plugins.get(path);
-                    if (/module\.exports|require\(/.test(code)) {
-                        console.warn(
-                            `Plugin ${path} uses CommonJS and will not work in the browser context.`,
-                        );
-                        continue;
-                    }
-                    const script = document.createElement("script");
-                    script.type = "text/javascript";
-                    script.text = code;
-                    document.body.appendChild(script);
-                    console.log(`Plugin loaded: ${path}`);
-                } catch (error) {
-                    console.error(`Failed to load plugin ${path}:`, error);
-                }
-            }
-        });
-    }, []);
-
-    useEffect(() => {
         window.electron.databaseIsReady().then((result) => {
             setDatabaseIsReady(result);
         });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -57,6 +57,30 @@ function App() {
     }, []);
 
     useEffect(() => {
+        console.log("Loading plugins...");
+        window.plugins?.list().then(async (pluginPaths: string[]) => {
+            for (const path of pluginPaths) {
+                try {
+                    const code = await window.plugins.get(path);
+                    if (/module\.exports|require\(/.test(code)) {
+                        console.warn(
+                            `Plugin ${path} uses CommonJS and will not work in the browser context.`,
+                        );
+                        continue;
+                    }
+                    const script = document.createElement("script");
+                    script.type = "text/javascript";
+                    script.text = code;
+                    document.body.appendChild(script);
+                    console.log(`Plugin loaded: ${path}`);
+                } catch (error) {
+                    console.error(`Failed to load plugin ${path}:`, error);
+                }
+            }
+        });
+    }, []);
+
+    useEffect(() => {
         window.electron.databaseIsReady().then((result) => {
             setDatabaseIsReady(result);
         });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -39,7 +39,9 @@ function App() {
             ?.list()
             .then(async (pluginPaths: string[]) => {
                 for (const path of pluginPaths) {
-                    console.log(`Loading plugin: ${path}`);
+                    const pluginName =
+                        path.split(/[/\\]/).pop() || "Unknown Plugin";
+                    console.log(`Loading plugin: ${pluginName}`);
                     try {
                         const code = await window.plugins.get(path);
                         const script = document.createElement("script");
@@ -47,7 +49,10 @@ function App() {
                         script.text = code;
                         document.body.appendChild(script);
                     } catch (error) {
-                        console.error(`Failed to load plugin ${path}:`, error);
+                        console.error(
+                            `Failed to load plugin ${pluginName}:`,
+                            error,
+                        );
                     }
                 }
             })

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -7,7 +7,7 @@ import { SelectedMarchersProvider } from "@/context/SelectedMarchersContext";
 import { IsPlayingProvider } from "@/context/IsPlayingContext";
 import StateInitializer from "@/components/singletons/StateInitializer";
 import LaunchPage from "@/components/LaunchPage";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FieldPropertiesProvider } from "@/context/fieldPropertiesContext";
 import RegisteredActionsHandler from "@/utilities/RegisteredActionsHandler";
 import TimelineContainer from "@/components/timeline/TimelineContainer";
@@ -29,6 +29,32 @@ import { useUiSettingsStore } from "./stores/UiSettingsStore";
 function App() {
     const [databaseIsReady, setDatabaseIsReady] = useState(false);
     const { fetchUiSettings } = useUiSettingsStore();
+    const pluginsLoadedRef = useRef(false);
+
+    useEffect(() => {
+        if (pluginsLoadedRef.current) return;
+        pluginsLoadedRef.current = true;
+        console.log("Loading plugins...");
+        window.plugins
+            ?.list()
+            .then(async (pluginPaths: string[]) => {
+                for (const path of pluginPaths) {
+                    console.log(`Loading plugin: ${path}`);
+                    try {
+                        const code = await window.plugins.get(path);
+                        const script = document.createElement("script");
+                        script.type = "text/javascript";
+                        script.text = code;
+                        document.body.appendChild(script);
+                    } catch (error) {
+                        console.error(`Failed to load plugin ${path}:`, error);
+                    }
+                }
+            })
+            .then(() => {
+                console.log("All plugins loaded.");
+            });
+    }, []);
 
     useEffect(() => {
         window.electron.databaseIsReady().then((result) => {

--- a/apps/desktop/src/components/canvas/Canvas.tsx
+++ b/apps/desktop/src/components/canvas/Canvas.tsx
@@ -317,7 +317,10 @@ export default function Canvas({
     /* -------------------------- useEffects -------------------------- */
     /* Initialize the canvas */
     useEffect(() => {
-        if (canvas || !selectedPage || !fieldProperties) return; // If the canvas is already initialized, or the selected page is not set, return
+        if (canvas || !selectedPage || !fieldProperties) {
+            window.canvas = canvas;
+            return;
+        } // If the canvas is already initialized, or the selected page is not set, return
 
         if (testCanvas) {
             setCanvas(testCanvas);
@@ -331,6 +334,8 @@ export default function Canvas({
                 }),
             );
         }
+
+        window.canvas = canvas;
     }, [selectedPage, fieldProperties, testCanvas, uiSettings, canvas]);
 
     // Initiate listeners

--- a/apps/desktop/src/preload.d.ts
+++ b/apps/desktop/src/preload.d.ts
@@ -1,10 +1,12 @@
 import { ElectronApi, PluginsApi } from "../electron/preload/index";
+import { OpenMarchCanvas } from "./global/classes/canvasObjects/OpenMarchCanvas";
 
 declare global {
     // eslint-disable-next-line no-unused-vars
     interface Window {
         electron: ElectronApi;
         plugins: PluginsApi;
+        canvas: OpenMarchCanvas;
     }
 }
 

--- a/apps/desktop/src/preload.d.ts
+++ b/apps/desktop/src/preload.d.ts
@@ -1,9 +1,10 @@
-import { ElectronApi } from "../electron/preload/index";
+import { ElectronApi, PluginsApi } from "../electron/preload/index";
 
 declare global {
     // eslint-disable-next-line no-unused-vars
     interface Window {
         electron: ElectronApi;
+        plugins: PluginsApi;
     }
 }
 


### PR DESCRIPTION
This PR makes a few changes:

### Plugin System
This introduces a basic plugin system to allow external scripts to be run in OpenMarch. This works by checking for any `.om.js` files in the `plugins` directory in `%appdata%` (or wherever the app configuration is stored). If the folder doesn't exist, OpenMarch automatically creates it.

The renderer requests a list of plugins and their code from a new plugins API, which utilizes the ipcRenderer to retrieve these from Electron. Plugins are loaded in `App.tsx` through creating script tags and inserting the plugin's code in them.

Note: In development environments, React may run the plugin loading system twice. There is a case to check for this, but it will not occur in production environments.


### Making the `OpenMarchCanvas` a global object
This adds the `OpenMarchCanvas` singleton to the global `window` object, allowing it to be accessed from the rest of OpenMarch and through plugins (e.g., calling `window.canvas._objects` to access all of the Marches on the canvas). In `Canvas.tsx`, `window.canvas` is set when the canvas first initializes.


Attached is an example plugin (the file extension is changed due to GitHub requirements)
[rainbowBorders.om.js.txt](https://github.com/user-attachments/files/20536239/rainbowBorders.om.js.txt)
