### PR TITLE
Disable undo and redo buttons when unavailable

### DIFF
--- a/apps/desktop/electron/database/database.history.ts
+++ b/apps/desktop/electron/database/database.history.ts
@@ -611,6 +611,26 @@ export function getCurrentRedoGroup(db: Database.Database) {
     ).cur_redo_group;
 }
 
+export function getUndoStackLength(db: Database.Database): number {
+    return (
+        db
+            .prepare(
+                `SELECT COUNT(*) as count FROM ${Constants.UndoHistoryTableName};`,
+            )
+            .get() as { count: number }
+    ).count;
+}
+
+export function getRedoStackLength(db: Database.Database): number {
+    return (
+        db
+            .prepare(
+                `SELECT COUNT(*) as count FROM ${Constants.RedoHistoryTableName};`,
+            )
+            .get() as { count: number }
+    ).count;
+}
+
 /**
  * Decrement all of the undo actions in the most recent group down by one.
  *

--- a/apps/desktop/electron/database/database.services.ts
+++ b/apps/desktop/electron/database/database.services.ts
@@ -525,6 +525,20 @@ export function initHandlers() {
         }),
     );
 
+    ipcMain.handle("history:getUndoStackLength", async () =>
+        connectWrapper(({ db }) => {
+            const undoLength = History.getUndoStackLength(db);
+            return { success: true, data: undoLength };
+        }),
+    );
+
+    ipcMain.handle("history:getRedoStackLength", async () =>
+        connectWrapper(({ db }) => {
+            const redoLength = History.getRedoStackLength(db);
+            return { success: true, data: redoLength };
+        }),
+    );
+
     ipcMain.handle(
         "section_appearances:createSectionAppearances",
         async (_event, newSectionAppearances) =>

--- a/apps/desktop/electron/preload/index.ts
+++ b/apps/desktop/electron/preload/index.ts
@@ -234,6 +234,8 @@ const APP_API = {
         ipcRenderer.invoke("history:getCurrentRedoGroup") as Promise<
             DatabaseResponse<number>
         >,
+    getUndoStackLength: () => ipcRenderer.invoke("history:getUndoStackLength"),
+    getRedoStackLength: () => ipcRenderer.invoke("history:getRedoStackLength"),
 
     // FieldProperties
     /** Get the FieldProperties associated with this file */

--- a/apps/desktop/src/components/singletons/StateInitializer.tsx
+++ b/apps/desktop/src/components/singletons/StateInitializer.tsx
@@ -13,6 +13,7 @@ import { MarcherShape } from "@/global/classes/canvasObjects/MarcherShape";
 import { useShapePageStore } from "@/stores/ShapePageStore";
 import { useFieldProperties } from "@/context/fieldPropertiesContext";
 import { useTimingObjectsStore } from "@/stores/TimingObjectsStore";
+import { useUndoRedoStore } from "@/stores/UndoRedoStore";
 
 /**
  * A component that initializes the state of the application.
@@ -28,6 +29,7 @@ function StateInitializer() {
     const { fetchShapePages, setSelectedMarcherShapes, selectedMarcherShapes } =
         useShapePageStore()!;
     const { fetchFieldProperties } = useFieldProperties()!;
+    const updateUndoRedo = useUndoRedoStore((s) => s.updateUndoRedo);
 
     /**
      * These functions set the fetch function in each respective class.
@@ -164,6 +166,8 @@ function StateInitializer() {
                         fetchFieldProperties();
                 }
             }
+
+            updateUndoRedo();
         };
 
         window.electron.onHistoryAction(handler);
@@ -171,6 +175,8 @@ function StateInitializer() {
         window.electron.onImportFieldPropertiesFile(() =>
             fetchFieldProperties(),
         );
+
+        updateUndoRedo();
 
         return () => {
             window.electron.removeHistoryActionListener(); // Remove the event listener

--- a/apps/desktop/src/components/titlebar/FileControls.tsx
+++ b/apps/desktop/src/components/titlebar/FileControls.tsx
@@ -6,11 +6,39 @@ import {
     FloppyDisk,
 } from "@phosphor-icons/react";
 import * as api from "@/api/api";
+import { useEffect, useState } from "react";
 import { RegisteredActionsObjects } from "@/utilities/RegisteredActionsHandler";
 import RegisteredActionButton from "@/components/RegisteredActionButton";
 import ExportCoordinatesModal from "../exporting/ExportCoordinatesModal";
 
 function FileControls() {
+    const [canUndo, setCanUndo] = useState(false);
+    const [canRedo, setCanRedo] = useState(false);
+
+    async function updateHistoryAvailability() {
+        const undoLength = await window.electron.getUndoStackLength();
+        const redoLength = await window.electron.getRedoStackLength();
+        setCanUndo(undoLength.data > 0);
+        setCanRedo(redoLength.data > 0);
+    }
+
+    useEffect(() => {
+        updateHistoryAvailability();
+
+        // DEBUG: poll every 1s to catch any missed events
+        const poll = setInterval(updateHistoryAvailability, 1000);
+
+        const handler = () => updateHistoryAvailability();
+        window.electron.onHistoryAction(handler);
+        window.electron.onFetch(handler);
+
+        return () => {
+            clearInterval(poll);
+            window.electron.removeHistoryActionListener();
+            window.electron.removeFetchListener();
+        };
+    }, []);
+
     return (
         <div className="titlebar-button flex gap-12" aria-label="File controls">
             <RegisteredActionButton
@@ -38,12 +66,16 @@ function FileControls() {
             <button
                 onClick={api.performUndo}
                 className="hover:text-accent outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:opacity-50"
+                disabled={!canUndo}
+                aria-disabled={!canUndo}
             >
                 <ArrowUUpLeft size={18} />
             </button>
             <button
                 onClick={api.performRedo}
                 className="hover:text-accent outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:opacity-50"
+                disabled={!canRedo}
+                aria-disabled={!canRedo}
             >
                 <ArrowUUpRight size={18} />
             </button>

--- a/apps/desktop/src/components/titlebar/FileControls.tsx
+++ b/apps/desktop/src/components/titlebar/FileControls.tsx
@@ -10,34 +10,11 @@ import { useEffect, useState } from "react";
 import { RegisteredActionsObjects } from "@/utilities/RegisteredActionsHandler";
 import RegisteredActionButton from "@/components/RegisteredActionButton";
 import ExportCoordinatesModal from "../exporting/ExportCoordinatesModal";
+import { useUndoRedoStore } from "@/stores/UndoRedoStore";
 
 function FileControls() {
-    const [canUndo, setCanUndo] = useState(false);
-    const [canRedo, setCanRedo] = useState(false);
-
-    async function updateHistoryAvailability() {
-        const undoLength = await window.electron.getUndoStackLength();
-        const redoLength = await window.electron.getRedoStackLength();
-        setCanUndo(undoLength.data > 0);
-        setCanRedo(redoLength.data > 0);
-    }
-
-    useEffect(() => {
-        updateHistoryAvailability();
-
-        // DEBUG: poll every 1s to catch any missed events
-        const poll = setInterval(updateHistoryAvailability, 1000);
-
-        const handler = () => updateHistoryAvailability();
-        window.electron.onHistoryAction(handler);
-        window.electron.onFetch(handler);
-
-        return () => {
-            clearInterval(poll);
-            window.electron.removeHistoryActionListener();
-            window.electron.removeFetchListener();
-        };
-    }, []);
+    const canUndo = useUndoRedoStore((s) => s.canUndo);
+    const canRedo = useUndoRedoStore((s) => s.canRedo);
 
     return (
         <div className="titlebar-button flex gap-12" aria-label="File controls">

--- a/apps/desktop/src/stores/UndoRedoStore.ts
+++ b/apps/desktop/src/stores/UndoRedoStore.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+
+interface UndoRedoState {
+    canUndo: boolean;
+    canRedo: boolean;
+    setCanUndo: (canUndo: boolean) => void;
+    setCanRedo: (canRedo: boolean) => void;
+    updateUndoRedo: () => Promise<void>;
+}
+
+export const useUndoRedoStore = create<UndoRedoState>((set) => ({
+    canUndo: false,
+    canRedo: false,
+    setCanUndo: (canUndo) => set({ canUndo }),
+    setCanRedo: (canRedo) => set({ canRedo }),
+    updateUndoRedo: async () => {
+        const undoLength = await window.electron.getUndoStackLength();
+        const redoLength = await window.electron.getRedoStackLength();
+        set({
+            canUndo: undoLength.data > 0,
+            canRedo: redoLength.data > 0,
+        });
+    },
+}));


### PR DESCRIPTION
Only disables buttons in React, not Electron.

Resolves #87 