### PR TITLE
Potential fix for code scanning alert no. 9: Artifact poisoning

### DIFF
--- a/.github/workflows/desktop-coverage.yaml
+++ b/.github/workflows/desktop-coverage.yaml
@@ -17,10 +17,12 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+            - run: mkdir -p ${{ runner.temp }}/artifacts/
             - uses: actions/download-artifact@v4
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   run-id: ${{ github.event.workflow_run.id }}
+                  path: ${{ runner.temp }}/artifacts/
             - name: Setup pnpm
               uses: pnpm/action-setup@v4.1.0
             - name: Install project dependencies


### PR DESCRIPTION
Potential fix for [https://github.com/OpenMarch/OpenMarch/security/code-scanning/9](https://github.com/OpenMarch/OpenMarch/security/code-scanning/9)

To address the artifact poisoning issue, the workflow should isolate the downloaded artifacts by extracting them into a temporary directory. This ensures that they cannot override existing files in the repository. Additionally, the workflow should verify the contents of the artifacts before using them. If the artifacts are not directly needed for the `pnpm install` step, the workflow should ensure that the installation process is not influenced by the downloaded artifacts.

The fix involves:
1. Creating a temporary directory for the artifacts.
2. Configuring `actions/download-artifact@v4` to extract the artifacts into the temporary directory.
3. Verifying the contents of the artifacts (if applicable) before proceeding with subsequent steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
