### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -4,6 +4,9 @@ on:
     pull_request:
         branches: ["main"]
 
+permissions:
+    contents: read
+
 jobs:
     format:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/OpenMarch/OpenMarch/security/code-scanning/7](https://github.com/OpenMarch/OpenMarch/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Since the workflow only formats code and does not interact with repository contents in a way that requires write access, we will set `contents: read` as the permission. This ensures the workflow has only the minimal access it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
