### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,9 @@ on:
     pull_request:
         branches: ["main"]
 
+permissions:
+    contents: read
+
 jobs:
     lint:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/OpenMarch/OpenMarch/security/code-scanning/8](https://github.com/OpenMarch/OpenMarch/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow. Since the workflow only needs to read repository contents to perform linting, we will set `contents: read` as the minimal required permission. This change ensures that the `GITHUB_TOKEN` has the least privilege necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
