### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -1,5 +1,8 @@
 name: Spellcheck
 
+permissions:
+    contents: read
+
 on:
     pull_request:
         branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/OpenMarch/OpenMarch/security/code-scanning/4](https://github.com/OpenMarch/OpenMarch/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs read-only operations, the `contents: read` permission is sufficient. This block should be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
