### PR TITLE
Changes the recent files store to use a "recent.json" file

### DIFF
--- a/apps/desktop/electron/main/services/recent-files-service.ts
+++ b/apps/desktop/electron/main/services/recent-files-service.ts
@@ -17,6 +17,7 @@ interface StoreSchema {
 
 // Initialize the store
 const store = new Store<StoreSchema>({
+    name: "recent",
     defaults: {
         recentFiles: [],
         maxRecentFiles: 10,


### PR DESCRIPTION
Resolves #517. This change in recent-files-service.ts makes it use a "recent.json" to store all recent file data, instead of the usual config.json.