### PR TITLE
Update default download count

### DIFF
--- a/apps/website/src/pages/download.astro
+++ b/apps/website/src/pages/download.astro
@@ -21,7 +21,7 @@ import DownloadCards from "@/components/download/DownloadCards.tsx";
         >
             <div class="w-[512px] flex flex-col gap-16 max-[600px]:w-full">
                 <p class="font-mono text-accent text-lg">
-                    <span class="font-bold" id="download-count">6,000+</span>
+                    <span class="font-bold" id="download-count">9,000+</span>
                     downloads & counting!
                 </p>
                 <h1 class="text-h2">Download the Modern Drill Writing App</h1>
@@ -72,7 +72,7 @@ import DownloadCards from "@/components/download/DownloadCards.tsx";
             return totalDownloads.toLocaleString();
         } catch (error) {
             console.error("Failed to fetch download count", error);
-            return "6,000+";
+            return "9,000+";
         }
     }
     getTotalDownloadCount().then((count) => {


### PR DESCRIPTION
Once we get to 10,000, I'm going to leave it at 10,000 until like 15,000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the Download page to display 9,000+ total downloads, reflecting the latest milestone.
  * Aligned the offline/error fallback to also show 9,000+ when live data isn’t available.
  * Ensures a consistent download count across the UI with no changes to layout or interaction.
  * No impact to functionality beyond the displayed count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->