### PR TITLE
Collision

### DIFF
--- a/apps/desktop/src/components/canvas/Canvas.tsx
+++ b/apps/desktop/src/components/canvas/Canvas.tsx
@@ -66,7 +66,7 @@ export default function Canvas({
     const containerRef = useRef<HTMLDivElement>(null);
     const frameRef = useRef<number | null>(null);
 
-    useAnimation({
+    const { currentCollisions } = useAnimation({
         canvas,
         pages,
         marchers,
@@ -764,6 +764,58 @@ export default function Canvas({
         marchers,
         marcherVisuals,
     ]);
+
+    // Render collision markers when paused
+    useEffect(() => {
+        if (!canvas) return;
+        // Remove existing collision markers
+        const existingMarkers = canvas
+            .getObjects()
+            .filter((obj: any) => obj.isCollisionMarker);
+        existingMarkers.forEach((marker) => canvas.remove(marker));
+        // Add new collision markers only when paused
+        if (!isPlaying && currentCollisions.length > 0) {
+            currentCollisions.forEach((collision) => {
+                // Create a red circle to mark collision location
+                const radius = 10;
+                const collisionMarker = new fabric.Circle({
+                    left: collision.x,
+                    top: collision.y,
+                    originX: "center",
+                    originY: "center",
+                    radius: collision.distance,
+                    fill: "rgba(255, 0, 0, 0.5)",
+                    stroke: "red",
+                    strokeWidth: 2,
+                    selectable: false,
+                    evented: false,
+                });
+                (collisionMarker as any).isCollisionMarker = true; // Custom property to identify collision markers
+                // Add text showing which marchers are colliding
+                const fontSize = 12;
+                const collisionText = new fabric.Text(
+                    `${collision.marcher1Id}-${collision.marcher2Id}`,
+                    {
+                        left: collision.x,
+                        top: collision.y - fontSize - collision.distance / 2,
+                        fontSize,
+                        fill: "red",
+                        textAlign: "center",
+                        originX: "center",
+                        originY: "center",
+                        selectable: false,
+                        evented: false,
+                    },
+                );
+                (collisionText as any).isCollisionMarker = true;
+
+                canvas.add(collisionMarker);
+                canvas.add(collisionText);
+            });
+
+            canvas.requestRenderAll();
+        }
+    }, [canvas, isPlaying, currentCollisions, selectedPage]);
 
     return (
         <div

--- a/apps/desktop/src/hooks/useAnimation.ts
+++ b/apps/desktop/src/hooks/useAnimation.ts
@@ -44,7 +44,6 @@ export const useAnimation = ({
         [],
     );
 
-    // Collision detection radius (in field units)
     const COLLISION_RADIUS = 15;
     const COLLISION_CHECK_INTERVAL = 100; // Check every 100ms for performance
 
@@ -89,15 +88,44 @@ export const useAnimation = ({
         return timelines;
     }, [marchers, pages, marcherPages]);
 
-    // Pre-calculate collisions for each page
-    const pageCollisions = useMemo(() => {
-        if (!marchers.length || !pages.length || marcherTimelines.size === 0) {
-            return new Map<number, CollisionData[]>();
-        }
+    // Cache for collision calculations
+    const collisionCacheRef = useRef<Map<number, CollisionData[]>>(new Map());
+    const pageHashCacheRef = useRef<Map<number, string>>(new Map());
 
-        // Start performance timer
-        const collisionsMap = new Map<number, CollisionData[]>();
-        for (const page of pages) {
+    // Function to create a hash for a page's collision dependencies
+    const getPageHash = useCallback(
+        (page: Page) => {
+            // filter marchers that belong to this page
+            const pageMarchers = marchers.filter((m) => {
+                const marcherPagesForMarcher = getByMarcherId(
+                    marcherPages,
+                    m.id,
+                );
+                return marcherPagesForMarcher.some(
+                    (mp) => mp.page_id === page.id,
+                );
+            });
+
+            // create marcher has
+            const marchersHash = pageMarchers
+                .map((m) => {
+                    const marcherPageData = getByMarcherId(
+                        marcherPages,
+                        m.id,
+                    ).find((mp) => mp.page_id === page.id);
+                    return `${m.id}-${m.drill_number}-${marcherPageData?.x}-${marcherPageData?.y}-${marcherPageData?.path_data}`;
+                })
+                .sort()
+                .join(",");
+
+            return `${page.id}-${page.timestamp}-${page.duration}-${marchersHash}-${COLLISION_RADIUS}`;
+        },
+        [marchers, marcherPages],
+    );
+
+    // Function to calculate collisions for a single page
+    const calculatePageCollisions = useCallback(
+        (page: Page): CollisionData[] => {
             const collisionPairs = new Set<string>();
             const collisions: CollisionData[] = [];
             const pageStartTime = page.timestamp * 1000; //convert to ms for more precision
@@ -170,26 +198,83 @@ export const useAnimation = ({
                     }
                 }
             }
+            return collisions;
+        },
+        [marchers, marcherTimelines],
+    );
 
-            collisionsMap.set(page.id, collisions);
+    // Incremental collision calculation with caching
+    const pageCollisions = useMemo(() => {
+        if (!marchers.length || !pages.length || marcherTimelines.size === 0) {
+            collisionCacheRef.current.clear();
+            pageHashCacheRef.current.clear();
+            return new Map<number, CollisionData[]>();
         }
+
+        const startTime = performance.now();
+        let pagesRecalculated = 0;
+        let pagesFromCache = 0;
+
+        const collisionsMap = new Map<number, CollisionData[]>();
+
+        for (const page of pages) {
+            const currentHash = getPageHash(page);
+            const cachedHash = pageHashCacheRef.current.get(page.id);
+
+            // Check if we can use cached collision data
+            if (
+                cachedHash === currentHash &&
+                collisionCacheRef.current.has(page.id)
+            ) {
+                // Use cached collision data
+                const cachedCollisions = collisionCacheRef.current.get(
+                    page.id,
+                )!;
+                collisionsMap.set(page.id, cachedCollisions);
+                pagesFromCache++;
+            } else {
+                // Recalculate collisions for this page
+                const collisions = calculatePageCollisions(page);
+                collisionsMap.set(page.id, collisions);
+
+                // Update cache
+                collisionCacheRef.current.set(page.id, collisions);
+                pageHashCacheRef.current.set(page.id, currentHash);
+                pagesRecalculated++;
+            }
+        }
+
+        // Clean up cache for pages that no longer exist in case user deletes page
+        const existingPageIds = new Set(pages.map((p) => p.id));
+        for (const cachedPageId of collisionCacheRef.current.keys()) {
+            if (!existingPageIds.has(cachedPageId)) {
+                collisionCacheRef.current.delete(cachedPageId);
+                pageHashCacheRef.current.delete(cachedPageId);
+            }
+        }
+
+        const endTime = performance.now();
+        console.log(
+            `Collision calculation: ${pagesRecalculated} pages recalculated, ${pagesFromCache} pages from cache in ${(endTime - startTime).toFixed(2)}ms`,
+        );
+
         return collisionsMap;
-    }, [marchers, pages, marcherPages, marcherTimelines]);
+    }, [
+        marchers,
+        pages,
+        marcherPages,
+        marcherTimelines,
+        getPageHash,
+        calculatePageCollisions,
+    ]);
 
     // Get collisions for the currently selected page
     const getCollisionsForSelectedPage = useCallback(() => {
         if (!selectedPage) {
-            console.log("No selected page, returning empty collisions");
             return [];
         }
 
         const collisions = pageCollisions.get(selectedPage.id + 1) || [];
-        console.log(
-            "Collisions for selected page:",
-            selectedPage.id,
-            ":",
-            collisions.length,
-        );
         return collisions;
     }, [pageCollisions, selectedPage]);
 

--- a/apps/desktop/src/hooks/useAnimation.ts
+++ b/apps/desktop/src/hooks/useAnimation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useIsPlaying } from "@/context/IsPlayingContext";
 import OpenMarchCanvas from "@/global/classes/canvasObjects/OpenMarchCanvas";
 import Page from "@/global/classes/Page";
@@ -9,9 +9,17 @@ import {
     getCoordinatesAtTime,
     MarcherTimeline,
 } from "@/utilities/Keyframes";
-import { Path } from "@openmarch/path-utility";
 import { getByMarcherId } from "@/global/classes/MarcherPage";
 import { getLivePlaybackPosition } from "@/components/timeline/audio/AudioPlayer";
+
+// Collision detection types
+interface CollisionData {
+    marcher1Id: number;
+    marcher2Id: number;
+    x: number;
+    y: number;
+    distance: number;
+}
 
 interface UseAnimationProps {
     canvas: OpenMarchCanvas | null;
@@ -32,6 +40,13 @@ export const useAnimation = ({
 }: UseAnimationProps) => {
     const { isPlaying, setIsPlaying } = useIsPlaying()!;
     const animationFrameRef = useRef<number | null>(null);
+    const [currentCollisions, setCurrentCollisions] = useState<CollisionData[]>(
+        [],
+    );
+
+    // Collision detection radius (in field units)
+    const COLLISION_RADIUS = 15;
+    const COLLISION_CHECK_INTERVAL = 100; // Check every 100ms for performance
 
     const marcherTimelines = useMemo(() => {
         const pagesMap = pages.reduce(
@@ -74,6 +89,117 @@ export const useAnimation = ({
         return timelines;
     }, [marchers, pages, marcherPages]);
 
+    // Pre-calculate collisions for each page
+    const pageCollisions = useMemo(() => {
+        if (!marchers.length || !pages.length || marcherTimelines.size === 0) {
+            return new Map<number, CollisionData[]>();
+        }
+
+        // Start performance timer
+        const collisionsMap = new Map<number, CollisionData[]>();
+        for (const page of pages) {
+            const collisionPairs = new Set<string>();
+            const collisions: CollisionData[] = [];
+            const pageStartTime = page.timestamp * 1000; //convert to ms for more precision
+            const pageEndTime = (page.timestamp + page.duration) * 1000;
+
+            // pre calculate positions
+            for (
+                let time = pageStartTime;
+                time < pageEndTime;
+                time += COLLISION_CHECK_INTERVAL
+            ) {
+                const marcherPositionsAtTime: Array<{
+                    id: number;
+                    x: number;
+                    y: number;
+                }> = [];
+
+                for (const marcher of marchers) {
+                    const timeline = marcherTimelines.get(marcher.id);
+                    if (!timeline) continue;
+
+                    try {
+                        const position = getCoordinatesAtTime(time, timeline);
+                        marcherPositionsAtTime.push({
+                            id: marcher.id,
+                            x: position.x,
+                            y: position.y,
+                        });
+                    } catch (e) {
+                        // Skip if marcher doesn't have position at this time
+                        continue;
+                    }
+                }
+
+                // detect collisions for this time slice
+                for (let i = 0; i < marcherPositionsAtTime.length; i++) {
+                    for (
+                        let j = i + 1;
+                        j < marcherPositionsAtTime.length;
+                        j++
+                    ) {
+                        const marcher1 = marcherPositionsAtTime[i];
+                        const marcher2 = marcherPositionsAtTime[j];
+
+                        // find the magnitude
+                        const mag = Math.sqrt(
+                            Math.pow(marcher1.x - marcher2.x, 2) +
+                                Math.pow(marcher1.y - marcher2.y, 2),
+                        );
+
+                        if (mag > COLLISION_RADIUS) continue;
+
+                        // Create collision pair key (order independent)
+                        const collisionString =
+                            marcher1.id < marcher2.id
+                                ? `${marcher1.id}-${marcher2.id}`
+                                : `${marcher2.id}-${marcher1.id}`;
+
+                        // if these two have gotten into a collision before ignore it
+                        if (collisionPairs.has(collisionString)) continue;
+
+                        collisionPairs.add(collisionString);
+                        collisions.push({
+                            x: (marcher1.x + marcher2.x) / 2,
+                            y: (marcher1.y + marcher2.y) / 2,
+                            distance: mag,
+                            marcher1Id: marcher1.id,
+                            marcher2Id: marcher2.id,
+                        });
+                    }
+                }
+            }
+
+            collisionsMap.set(page.id, collisions);
+        }
+        return collisionsMap;
+    }, [marchers, pages, marcherPages, marcherTimelines]);
+
+    // Get collisions for the currently selected page
+    const getCollisionsForSelectedPage = useCallback(() => {
+        if (!selectedPage) {
+            console.log("No selected page, returning empty collisions");
+            return [];
+        }
+
+        const collisions = pageCollisions.get(selectedPage.id + 1) || [];
+        console.log(
+            "Collisions for selected page:",
+            selectedPage.id,
+            ":",
+            collisions.length,
+        );
+        return collisions;
+    }, [pageCollisions, selectedPage]);
+
+    // Update collisions when selected page changes
+    useEffect(() => {
+        const collisions = getCollisionsForSelectedPage();
+        setCurrentCollisions(collisions);
+    }, [selectedPage, getCollisionsForSelectedPage]);
+
+    // Set marcher positions at a specific time
     const setMarcherPositionsAtTime = useCallback(
         (timeMilliseconds: number) => {
             if (!canvas) return;
@@ -116,23 +242,13 @@ export const useAnimation = ({
                 // We're past the end, set the selected page to the last one and stop playing
                 setSelectedPage(pages[pages.length - 1]);
                 setIsPlaying(false);
-            } else {
-                const previousPage =
-                    (currentPage &&
-                        currentPage.previousPageId != null &&
-                        pages.find(
-                            (p) => p.id === currentPage?.previousPageId,
-                        )) ??
-                    pages[0];
-                if (!previousPage)
-                    throw new Error(
-                        "Could not find any page to select. This should not happen",
-                    );
-
-                setSelectedPage(previousPage);
+                const lastPage = pages[pages.length - 1];
+                if (lastPage !== selectedPage) {
+                    setSelectedPage(lastPage);
+                }
             }
         },
-        [pages, canvas, setSelectedPage, setIsPlaying],
+        [pages, selectedPage, setSelectedPage, setIsPlaying],
     );
 
     // Animate the canvas based on playback timestamp
@@ -165,5 +281,5 @@ export const useAnimation = ({
         };
     }, [isPlaying, canvas, setMarcherPositionsAtTime, updateSelectedPage]);
 
-    return { setMarcherPositionsAtTime };
+    return { setMarcherPositionsAtTime, currentCollisions };
 };


### PR DESCRIPTION
Added collision detection within the useAnimation hook.

Added a pagehash cache so only pages that change marchers are re computed saving compute time. 

Changed canvas to add little red circles depending on the collision. Currently a larger circle means marchers get close while smaller means they're basically ontop of eachother. 

note. In the future if users are allowed to change the radius of the marcher, like tenors have 10 vs snare is 5. Changing the COLLISION_RADIUS to a dynamic value should be a pretty easy change. 