### PR TITLE
Fix #609

### DIFF
--- a/apps/desktop/turbo.json
+++ b/apps/desktop/turbo.json
@@ -5,7 +5,9 @@
             "with": [
                 "@openmarch/core#dev",
                 "@openmarch/musicxml-parser#dev",
-                "@openmarch/ui#dev"
+                "@openmarch/ui#dev",
+                "@openmarch/path-utility#dev",
+                "@openmarch/metronome#dev"
             ],
             "persistent": true,
             "cache": false


### PR DESCRIPTION
Fixes #609 by adding required @openmarch/* dependencies to the dev task in `apps/desktop/turbo.json`.