### PR TITLE
Fix audio file loading error

### DIFF
--- a/apps/desktop/src/global/classes/AudioFile.ts
+++ b/apps/desktop/src/global/classes/AudioFile.ts
@@ -32,7 +32,10 @@ export default class AudioFile {
     }) {
         this.id = id;
 
-        if (data instanceof Uint8Array) {
+        // Handle the case where data is undefined (for getAudioFilesDetails)
+        if (data === undefined) {
+            this.data = undefined;
+        } else if (data instanceof Uint8Array) {
             this.data = data.buffer.slice(
                 data.byteOffset,
                 data.byteOffset + data.byteLength,


### PR DESCRIPTION
close Fix failing E2E tests #608
The e2e tests were failing because the audio loader wasn't properly rendering di to an error Uncaught (in promise) Error: Unable to create AudioFile: data must be an ArrayBuffer or Uint8Array, but instead got: undefined
    at new AudioFile (AudioFile.ts:43:19)
    at AudioFile.ts:64:50
    at Array.map (<anonymous>)
    at AudioFile.getAudioFilesDetails (AudioFile.ts:64:27)