### PR TITLE
Fix #597 Toast and warning for missing recent files

### DIFF
--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -228,11 +228,11 @@ app.whenReady().then(async () => {
     );
 
     // Recent files handlers
-    ipcMain.handle("recent-files:get", async () => getRecentFiles());
-    ipcMain.handle("recent-files:remove", async (_, filePath) =>
+    ipcMain.handle("recent-files:get", getRecentFiles);
+    ipcMain.handle("recent-files:remove", (_, filePath) =>
         removeRecentFile(filePath),
     );
-    ipcMain.handle("recent-files:clear", async () => clearRecentFiles());
+    ipcMain.handle("recent-files:clear", clearRecentFiles);
     ipcMain.handle("recent-files:open", async (_, filePath) => {
         if (!filePath || !fs.existsSync(filePath)) return -1;
 

--- a/apps/desktop/electron/main/services/recent-files-service.ts
+++ b/apps/desktop/electron/main/services/recent-files-service.ts
@@ -1,5 +1,6 @@
 import Store from "electron-store";
 import * as path from "path";
+import { existsSync } from "fs";
 
 // Define types
 export interface RecentFile {
@@ -7,6 +8,7 @@ export interface RecentFile {
     name: string;
     lastOpened: number; // timestamp
     svgPreview?: string; // SVG preview of the first page
+    isMissing?: boolean; // Whether the file is missing
 }
 
 // Create a typed store
@@ -64,7 +66,16 @@ export function addRecentFile(filePath: string, svgPreview?: string): void {
  * @returns Array of recent files sorted by most recently opened
  */
 export function getRecentFiles(): RecentFile[] {
-    return store.get("recentFiles", []);
+    const recentFiles = store.get("recentFiles", []);
+
+    // apply isMissing flag as needed
+    recentFiles.forEach((recentFile) => {
+        if (!recentFile.path || !existsSync(recentFile.path)) {
+            recentFile.isMissing = true;
+        }
+    });
+
+    return recentFiles;
 }
 
 /**

--- a/apps/desktop/electron/preload/index.ts
+++ b/apps/desktop/electron/preload/index.ts
@@ -45,6 +45,7 @@ import {
 } from "electron/database/tables/UtilityTable";
 
 import Plugin from "../../src/global/classes/Plugin";
+import { RecentFile } from "electron/main/services/recent-files-service";
 
 function domReady(
     condition: DocumentReadyState[] = ["complete", "interactive"],
@@ -199,7 +200,8 @@ const APP_API = {
     },
 
     // Recent files
-    getRecentFiles: () => ipcRenderer.invoke("recent-files:get"),
+    getRecentFiles: () =>
+        ipcRenderer.invoke("recent-files:get") as Promise<RecentFile[]>,
     removeRecentFile: (filePath: string) =>
         ipcRenderer.invoke("recent-files:remove", filePath),
     clearRecentFiles: () => ipcRenderer.invoke("recent-files:clear"),
@@ -527,14 +529,6 @@ const PLUGINS_API = {
 };
 
 contextBridge.exposeInMainWorld("plugins", PLUGINS_API);
-
-// Define the RecentFile interface for the type system
-export interface RecentFile {
-    path: string;
-    name: string;
-    lastOpened: number;
-    svgPreview?: string;
-}
 
 export type ElectronApi = typeof APP_API;
 export type PluginsApi = typeof PLUGINS_API;

--- a/apps/desktop/i18n/en.json
+++ b/apps/desktop/i18n/en.json
@@ -456,6 +456,7 @@
             "failedToOpen": "Failed to open file",
             "failedToRemoveRecent": "Failed to remove file from recent list",
             "fieldPreview": "Field Preview",
+            "movedOrMissing": "File moved or missing",
             "openFile": "Open File",
             "removeFile": "Remove from recent files",
             "title": "Recent Files"

--- a/apps/desktop/src/components/launchpage/files/FilesContent.tsx
+++ b/apps/desktop/src/components/launchpage/files/FilesContent.tsx
@@ -5,6 +5,7 @@ import WelcomeContent from "./WelcomeContent";
 import { toast } from "sonner";
 import { Button } from "@openmarch/ui";
 import { T, useTolgee } from "@tolgee/react";
+import { WarningCircleIcon } from "@phosphor-icons/react";
 
 import { RecentFile } from "electron/main/services/recent-files-service";
 
@@ -116,6 +117,14 @@ export default function FilesTabContent() {
                                         <div className="text-h5 truncate">
                                             {file.name}
                                         </div>
+                                        {file.isMissing && (
+                                            <div className="text-red text-body flex items-center gap-4">
+                                                <WarningCircleIcon size={16} />
+                                                {t(
+                                                    "launchpage.files.movedOrMissing",
+                                                )}
+                                            </div>
+                                        )}
                                         <div className="text-text-subtitle text-body">
                                             {new Date(
                                                 file.lastOpened,

--- a/apps/desktop/src/components/launchpage/files/FilesContent.tsx
+++ b/apps/desktop/src/components/launchpage/files/FilesContent.tsx
@@ -37,6 +37,8 @@ export default function FilesTabContent() {
             if (result === 200) {
                 // File opened successfully, the app will reload
                 console.log("File opened successfully");
+            } else {
+                toast.error(t("launchpage.files.failedToOpen"));
             }
         } catch (error) {
             console.error("Failed to open file:", error);

--- a/apps/desktop/src/components/launchpage/files/FilesContent.tsx
+++ b/apps/desktop/src/components/launchpage/files/FilesContent.tsx
@@ -6,12 +6,7 @@ import { toast } from "sonner";
 import { Button } from "@openmarch/ui";
 import { T, useTolgee } from "@tolgee/react";
 
-interface RecentFile {
-    path: string;
-    name: string;
-    lastOpened: number;
-    svgPreview?: string;
-}
+import { RecentFile } from "electron/main/services/recent-files-service";
 
 export default function FilesTabContent() {
     const { t } = useTolgee();

--- a/apps/desktop/src/components/launchpage/files/FilesContent.tsx
+++ b/apps/desktop/src/components/launchpage/files/FilesContent.tsx
@@ -32,14 +32,20 @@ export default function FilesTabContent() {
         }
     };
 
-    const handleOpenFile = async (filePath: string) => {
+    const handleOpenFile = async (file: RecentFile) => {
         try {
-            const result = await window.electron.openRecentFile(filePath);
+            const result = await window.electron.openRecentFile(file.path);
             if (result === 200) {
                 // File opened successfully, the app will reload
                 console.log("File opened successfully");
             } else {
                 toast.error(t("launchpage.files.failedToOpen"));
+
+                // Edge case that file moved/deleted after recent file fetch
+                if (!file.isMissing) {
+                    // refresh the recent files list, which should confirm file is missing
+                    await loadRecentFiles();
+                }
             }
         } catch (error) {
             console.error("Failed to open file:", error);
@@ -88,7 +94,7 @@ export default function FilesTabContent() {
                         {recentFiles.map((file) => (
                             <div
                                 key={file.path}
-                                onClick={() => handleOpenFile(file.path)}
+                                onClick={() => handleOpenFile(file)}
                                 className="bg-fg-1 border-stroke rounded-16 hover:border-accent flex cursor-pointer flex-col items-center justify-between gap-12 border p-8 transition-colors"
                             >
                                 <div className="bg-fg-2 border-stroke rounded-6 flex aspect-video h-auto w-full items-center justify-center border">

--- a/apps/desktop/src/components/launchpage/files/FilesContent.tsx
+++ b/apps/desktop/src/components/launchpage/files/FilesContent.tsx
@@ -95,7 +95,7 @@ export default function FilesTabContent() {
                             <div
                                 key={file.path}
                                 onClick={() => handleOpenFile(file)}
-                                className="bg-fg-1 border-stroke rounded-16 hover:border-accent flex cursor-pointer flex-col items-center justify-between gap-12 border p-8 transition-colors"
+                                className="bg-fg-1 border-stroke rounded-16 hover:border-accent flex cursor-pointer flex-col items-center gap-12 border p-8 transition-colors"
                             >
                                 <div className="bg-fg-2 border-stroke rounded-6 flex aspect-video h-auto w-full items-center justify-center border">
                                     {file.svgPreview ? (
@@ -118,8 +118,8 @@ export default function FilesTabContent() {
                                         />
                                     )}
                                 </div>
-                                <div className="flex w-full items-start justify-between p-4">
-                                    <div className="flex flex-col gap-6">
+                                <div className="flex w-full flex-1 justify-between p-4">
+                                    <div className="flex flex-col justify-between gap-6">
                                         <div className="text-h5 truncate">
                                             {file.name}
                                         </div>


### PR DESCRIPTION
Fix for #597. When a recent file is missing on the file system, a warning is displayed on its listing, and a toast is displayed if a user attempts to open it.

If a file is deleted after initial launch screen load and recent file fetch, and the user attempts to open the file, the recent file list is also refreshed in order to update missing file warnings.

The toast didn't display originally because the 'recent-file:open' ipcMain handler returns -1 and doesn't throw when a file doesn't exist. It looks like underlying data operations could throw, however. Looking through the rest of the file, I see there's a mix of throwing and return -1 (is there a reason for this?), so I chose to leave both the `else` and `catch` blocks in for now.

Translations for `launchpage.files.movedOrMissing` will need to be added.