### PR TITLE
638 bug performer number incorrect on coordinate sheet exports

### DIFF
--- a/apps/desktop/src/components/exporting/ExportCoordinatesModal.tsx
+++ b/apps/desktop/src/components/exporting/ExportCoordinatesModal.tsx
@@ -136,9 +136,13 @@ function CoordinateSheetExport() {
             const processedMarchers = marchers
                 .map((marcher) => ({
                     ...marcher,
+                    // Use raw DB section with the numeric part of drill_number as fallback display name
                     name:
                         marcher.name ||
-                        `${marcher.section} ${marcher.drill_order}`,
+                        `${marcher.section} ${
+                            marcher.drill_number.match(/\d+/)?.[0] ||
+                            String(marcher.drill_order)
+                        }`,
                 }))
                 .sort((a, b) => {
                     const sectionCompare = (a.section || "").localeCompare(
@@ -506,6 +510,7 @@ function CoordinateSheetExport() {
                         <T keyName="exportCoordinates.roundingDenominator" />
                     </Form.Label>
                     <Select
+                        modal={false}
                         value={roundingDenominator.toString()}
                         onValueChange={(value: string) =>
                             setRoundingDenominator(parseInt(value))

--- a/apps/desktop/src/components/exporting/ExportCoordinatesModal.tsx
+++ b/apps/desktop/src/components/exporting/ExportCoordinatesModal.tsx
@@ -1244,24 +1244,28 @@ function ExportModalContents() {
 
 export default function ExportCoordinatesModal() {
     return (
-        <Dialog>
-            <DialogTrigger
-                asChild
-                className="hover:text-accent flex items-center gap-8 outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:opacity-50"
-            >
-                <button type="button" className="flex items-center gap-8">
-                    <ArrowSquareOutIcon size={24} />
-                    <T keyName="exportCoordinates.exportButton" />
-                </button>
-            </DialogTrigger>
+        <>
+            <style>{`.export-coordinates-dialog + [data-radix-popper-content-wrapper],
+                .export-coordinates-dialog ~ [data-radix-popper-content-wrapper]{z-index:10000 !important;}`}</style>
+            <Dialog>
+                <DialogTrigger
+                    asChild
+                    className="hover:text-accent flex items-center gap-8 outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:opacity-50"
+                >
+                    <button type="button" className="flex items-center gap-8">
+                        <ArrowSquareOutIcon size={24} />
+                        <T keyName="exportCoordinates.exportButton" />
+                    </button>
+                </DialogTrigger>
 
-            {/* Dialog Setup */}
-            <DialogContent className="w-[48rem]">
-                <DialogTitle>
-                    <T keyName="exportCoordinates.title" />
-                </DialogTitle>
-                <ExportModalContents />
-            </DialogContent>
-        </Dialog>
+                {/* Dialog Setup */}
+                <DialogContent className="export-coordinates-dialog w-[48rem]">
+                    <DialogTitle>
+                        <T keyName="exportCoordinates.title" />
+                    </DialogTitle>
+                    <ExportModalContents />
+                </DialogContent>
+            </Dialog>
+        </>
     );
 }

--- a/packages/ui/src/components/base/Select.tsx
+++ b/packages/ui/src/components/base/Select.tsx
@@ -107,7 +107,7 @@ export const SelectContent = ({ children }: RadixSelectContentProps) => {
         <RadixSelect.Portal>
             <RadixSelect.Content
                 position="popper"
-                className="rounded-6 border-stroke bg-modal data-[state='open']:animate-scale-in relative z-50 mt-4 max-h-[512px] w-full max-w-[384px] overflow-hidden border px-22 font-sans backdrop-blur-3xl"
+                className="rounded-6 border-stroke bg-modal data-[state='open']:animate-scale-in relative z-[9999] mt-4 max-h-[512px] w-full max-w-[384px] overflow-hidden border px-22 font-sans backdrop-blur-3xl"
             >
                 <RadixSelect.ScrollUpButton className="border-stroke text-text flex h-fit cursor-default items-center justify-center border-b py-2">
                     <CaretUpIcon size={18} />


### PR DESCRIPTION
### Summary
Fix performer label on coordinate sheet exports and make the “Coordinate rounding” dropdown render above the export modal without losing styles.

### Why
- Coordinate sheets were showing “Section + global index” (e.g., “baritone 19”) instead of the performer’s in-section number. See issue [#638](https://github.com/OpenMarch/OpenMarch/issues/638).
- The rounding dropdown was opening behind the modal due to stacking context, making it hard to use.

### What changed
- Coordinate sheet export naming
  - Use the numeric part of `drill_number` with the raw DB `section` to build fallback names when `name` is empty (e.g., “Baritone 1” for `B1`).
  - Preserve user-provided `name` if present.
  - No DB changes; only affects export-time labels.
- Export modal dropdown layering
  - Kept `@openmarch/ui` `SelectContent` to retain styles and behavior.
  - Set `modal={false}` on the `Select` to avoid focus-trap/stacking issues.
  - Scoped a tiny CSS override inside the export component to elevate only the export modal’s Select popper:
    - Added `export-coordinates-dialog` class to the modal content.
    - Injected a scoped `<style>` block in `ExportCoordinatesModal` that raises the adjacent Radix popper wrapper.

### Files of note
- `apps/desktop/src/components/exporting/ExportCoordinatesModal.tsx`
  - Fallback name logic: section + numeric part of `drill_number`.
  - `Select` now `modal={false}`.
  - Scoped style + `export-coordinates-dialog` class to limit z-index changes to this modal.

### Verification
- Coordinate sheets:
  - Export a set with multiple sections and missing `name`s.
  - Verify headers show “<Section> <numberFrom(drill_number)>” (e.g., “Baritone 1”), not a global index.
  - Custom names remain unchanged.
- Rounding dropdown:
  - Open Export → Coordinate Sheets.
  - Click “Coordinate rounding” dropdown; it should render above the modal, with full styling and selectable options.

### Risk/Impact
- Low. The z-index override is scoped to the export modal only.
- No change to DB schema or persisted data.
- File naming for per-marcher PDFs remains `drill_number`-based as before.