### PR TITLE
Pathways render properly

### DIFF
--- a/apps/desktop/src/components/canvas/Canvas.tsx
+++ b/apps/desktop/src/components/canvas/Canvas.tsx
@@ -380,11 +380,16 @@ export default function Canvas({
         frameRef.current = requestAnimationFrame(() => {
             if (!canvas || !selectedPage || !marcherPages) return;
 
+            // Render paths based on UI settings (pass empty objects for disabled paths)
             canvas.renderPathVisuals({
                 marcherVisuals: marcherVisuals,
-                previousMarcherPages: previousMarcherPages || {},
+                previousMarcherPages: uiSettings.previousPaths
+                    ? previousMarcherPages || {}
+                    : {},
                 currentMarcherPages: marcherPages,
-                nextMarcherPages: nextMarcherPages || {},
+                nextMarcherPages: uiSettings.nextPaths
+                    ? nextMarcherPages || {}
+                    : {},
                 marcherIds: selectedMarchers.map((m) => m.id),
             });
 
@@ -398,6 +403,8 @@ export default function Canvas({
         previousMarcherPages,
         selectedMarchers,
         selectedPage,
+        uiSettings.nextPaths,
+        uiSettings.previousPaths,
     ]);
 
     useEffect(() => {
@@ -587,18 +594,21 @@ export default function Canvas({
             canvas.add(visualGroup.getCanvasMarcher().textLabel);
 
             canvas.add(visualGroup.getPreviousPathway());
-            visualGroup
-                .getNextPathway()
-                .getFabricObjects()
-                .forEach((fabricObject: fabric.Object) => {
-                    canvas.add(fabricObject);
-                });
+            // TODO: Uncomment when EditablePath is fully implemented
+            // visualGroup
+            //     .getNextPathway()
+            //     .getFabricObjects()
+            //     .forEach((fabricObject: fabric.Object) => {
+            //         canvas.add(fabricObject);
+            //     });
+            // Using simple pathway method (like previous paths) for now
+            canvas.add(visualGroup.getNextPathway());
             visualGroup
                 .getPreviousPathway()
                 .setColor(fieldProperties.theme.previousPath);
-            // visualGroup
-            //     .getNextPathway()
-            //     .setColor(fieldProperties.theme.nextPath);
+            visualGroup
+                .getNextPathway()
+                .setColor(fieldProperties.theme.nextPath);
 
             canvas.add(visualGroup.getPreviousMidpoint());
             canvas.add(visualGroup.getNextMidpoint());
@@ -666,24 +676,28 @@ export default function Canvas({
         if (!canvas || !selectedPage || !fieldProperties || !marcherPagesLoaded)
             return;
 
-        if (marchers && (uiSettings.nextPaths || uiSettings.previousPaths)) {
+        if (marchers) {
+            // Always call renderPathVisuals, but it will show/hide based on settings
             canvas.renderPathVisuals({
                 marcherVisuals: marcherVisuals,
                 currentMarcherPages: marcherPages,
-                previousMarcherPages: marcherPages,
-                nextMarcherPages: marcherPages,
+                previousMarcherPages: uiSettings.previousPaths
+                    ? previousMarcherPages || {}
+                    : {},
+                nextMarcherPages: uiSettings.nextPaths
+                    ? nextMarcherPages || {}
+                    : {},
 
                 marcherIds: marchers.map((m) => m.id),
             });
             canvas.sendCanvasMarchersToFront();
-        } else {
-            canvas.hideAllPathVisuals({ marcherVisuals: marcherVisuals });
-            canvas.requestRenderAll();
         }
     }, [
         canvas,
         fieldProperties,
         marcherPages,
+        previousMarcherPages,
+        nextMarcherPages,
         marchers,
         pages,
         selectedPage,

--- a/apps/desktop/src/components/inspector/PageEditor.tsx
+++ b/apps/desktop/src/components/inspector/PageEditor.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import { useSelectedPage } from "../../context/SelectedPageContext";
 import { InspectorCollapsible } from "./InspectorCollapsible";
 import { Button, Switch, TextArea } from "@openmarch/ui";
-import { useTimingObjects } from "../../hooks";
 import { measureRangeString } from "../../global/classes/Page";
 import { T, useTranslate } from "@tolgee/react";
 import { updatePagesMutationOptions } from "../../hooks/queries";
@@ -14,12 +13,11 @@ function PageEditor() {
     const queryClient = useQueryClient();
     const { t } = useTranslate();
     const { selectedPage } = useSelectedPage()!;
-    const { pages } = useTimingObjects()!;
     const updatePagesMutation = useMutation(
         updatePagesMutationOptions(queryClient),
     );
     const splitPage = useSplitPage().mutate;
-    const [isFirstPage, setIsFirstPage] = useState(false);
+    const isFirstPage = selectedPage?.previousPageId === null;
     const [notes, setNotes] = useState(selectedPage?.notes || "");
 
     const countsInputId = "page-counts";
@@ -57,13 +55,6 @@ function PageEditor() {
     useEffect(() => {
         if (selectedPage) resetForm();
     }, [selectedPage]);
-
-    useEffect(() => {
-        if (pages.length > 0) {
-            const firstPage = pages[0];
-            setIsFirstPage(selectedPage === firstPage);
-        }
-    }, [pages, selectedPage]);
 
     if (selectedPage)
         return (

--- a/apps/desktop/src/components/toolbar/tabs/ViewTab.tsx
+++ b/apps/desktop/src/components/toolbar/tabs/ViewTab.tsx
@@ -1,12 +1,9 @@
 import { useUiSettingsStore } from "@/stores/UiSettingsStore";
-import { RegisteredActionsObjects } from "@/utilities/RegisteredActionsHandler";
-import RegisteredActionButton from "@/components/RegisteredActionButton";
 import ToolbarSection from "@/components/toolbar/ToolbarSection";
 import {
     ArrowsInSimpleIcon,
     EyeIcon,
     EyeSlashIcon,
-    WarningCircleIcon,
 } from "@phosphor-icons/react";
 import { T, useTolgee } from "@tolgee/react";
 
@@ -25,16 +22,14 @@ function UiSettingsToolbar() {
     return (
         <>
             <ToolbarSection aria-label={t("toolbar.view.uiSettingsToolbar")}>
-                <RegisteredActionButton
-                    registeredAction={
-                        RegisteredActionsObjects.togglePreviousPagePaths
-                    }
-                    instructionalString={
-                        uiSettings.previousPaths
-                            ? RegisteredActionsObjects.togglePreviousPagePaths.getInstructionalStringToggleOff()
-                            : RegisteredActionsObjects.togglePreviousPagePaths.getInstructionalStringToggleOn()
-                    }
-                    className={`hover:text-accent flex gap-8 outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:pointer-events-none disabled:opacity-50`}
+                <button
+                    onClick={() => {
+                        setUiSettings({
+                            ...uiSettings,
+                            previousPaths: !uiSettings.previousPaths,
+                        });
+                    }}
+                    className="hover:text-accent flex items-center gap-8 outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:opacity-50"
                 >
                     <T keyName="toolbar.view.previousPaths" />
                     {uiSettings.previousPaths ? (
@@ -42,17 +37,15 @@ function UiSettingsToolbar() {
                     ) : (
                         <EyeSlashIcon size={24} />
                     )}
-                </RegisteredActionButton>
-                <RegisteredActionButton
-                    registeredAction={
-                        RegisteredActionsObjects.toggleNextPagePaths
-                    }
-                    instructionalString={
-                        uiSettings.nextPaths
-                            ? RegisteredActionsObjects.toggleNextPagePaths.getInstructionalStringToggleOff()
-                            : RegisteredActionsObjects.toggleNextPagePaths.getInstructionalStringToggleOn()
-                    }
-                    className={`hover:text-accent flex gap-8 outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:pointer-events-none disabled:opacity-50`}
+                </button>
+                <button
+                    onClick={() => {
+                        setUiSettings({
+                            ...uiSettings,
+                            nextPaths: !uiSettings.nextPaths,
+                        });
+                    }}
+                    className="hover:text-accent flex items-center gap-8 outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:opacity-50"
                 >
                     <T keyName="toolbar.view.nextPaths" />
                     {uiSettings.nextPaths ? (
@@ -60,7 +53,7 @@ function UiSettingsToolbar() {
                     ) : (
                         <EyeSlashIcon size={24} />
                     )}
-                </RegisteredActionButton>
+                </button>
             </ToolbarSection>
             <ToolbarSection>
                 <button

--- a/apps/desktop/src/global/classes/MarcherVisualGroup.ts
+++ b/apps/desktop/src/global/classes/MarcherVisualGroup.ts
@@ -7,7 +7,7 @@ import {
     getSectionAppearance,
     SectionAppearance,
 } from "@/global/classes/SectionAppearance";
-import EditablePath from "./canvasObjects/EditablePath";
+// import EditablePath from "./canvasObjects/EditablePath";
 import { FieldTheme } from "@openmarch/core";
 
 /**
@@ -23,7 +23,7 @@ export default class MarcherVisualGroup {
 
     /** Unselectable visual elements of pathways */
     previousPathway: Pathway;
-    nextPathway: EditablePath;
+    nextPathway: Pathway; // TODO: Change back to EditablePath when it's fully implemented
     previousMidpoint: Midpoint;
     nextMidpoint: Midpoint;
     previousEndPoint: Endpoint;
@@ -58,8 +58,13 @@ export default class MarcherVisualGroup {
             color: "black",
             strokeWidth: 2,
         });
-        this.nextPathway = new EditablePath({
-            fieldTheme,
+        // TODO: Change back to EditablePath when it's fully implemented
+        this.nextPathway = new Pathway({
+            marcherId: this.marcherId,
+            start: { x: 0, y: 0 },
+            end: { x: 0, y: 0 },
+            color: "green",
+            strokeWidth: 2,
         });
 
         this.previousMidpoint = new Midpoint({

--- a/apps/desktop/src/global/classes/canvasObjects/OpenMarchCanvas.ts
+++ b/apps/desktop/src/global/classes/canvasObjects/OpenMarchCanvas.ts
@@ -1153,36 +1153,40 @@ export default class OpenMarchCanvas extends fabric.Canvas {
 
             // next pathway, midpoint, endpoint
             if (!nextPageIsEmpty && next && curr) {
-                // delete all of the existing fabric objects
-                for (const fabricObject of visual
-                    .getNextPathway()
-                    .getFabricObjects()) {
-                    this.remove(fabricObject);
-                }
+                // TODO: Uncomment when EditablePath is fully implemented
+                // // delete all of the existing fabric objects
+                // for (const fabricObject of visual
+                //     .getNextPathway()
+                //     .getFabricObjects()) {
+                //     this.remove(fabricObject);
+                // }
 
-                const nextPathway = visual.getNextPathway();
-                nextPathway.updatePathwayWithMarcherPages(curr, next);
-                for (const fabricObject of nextPathway.getFabricObjects()) {
-                    this.add(fabricObject);
-                }
+                // const nextPathway = visual.getNextPathway();
+                // nextPathway.updatePathwayWithMarcherPages(curr, next);
+                // for (const fabricObject of nextPathway.getFabricObjects()) {
+                //     this.add(fabricObject);
+                // }
 
-                // visual.getNextPathway().updateStartCoords(curr);
-                // visual.getNextPathway().updateEndCoords(next);
+                // Using simple pathway method (like previous paths) for now
+                visual.getNextPathway().show();
+                visual.getNextPathway().updateStartCoords(curr);
+                visual.getNextPathway().updateEndCoords(next);
 
-                // visual.getNextMidpoint().show();
-                // visual.getNextMidpoint().updateCoords({
-                //     x: (curr.x + next.x) / 2,
-                //     y: (curr.y + next.y) / 2,
-                // });
+                visual.getNextMidpoint().show();
+                visual.getNextMidpoint().updateCoords({
+                    x: (curr.x + next.x) / 2,
+                    y: (curr.y + next.y) / 2,
+                });
 
-                // visual.getNextEndpoint().show();
-                // visual.getNextEndpoint().updateCoords(next);
-                this.requestRenderAll();
+                visual.getNextEndpoint().show();
+                visual.getNextEndpoint().updateCoords(next);
             } else {
-                const nextPathway = visual.getNextPathway();
-                for (const fabricObject of nextPathway.getFabricObjects()) {
-                    this.remove(fabricObject);
-                }
+                // TODO: Uncomment when EditablePath is fully implemented
+                // const nextPathway = visual.getNextPathway();
+                // for (const fabricObject of nextPathway.getFabricObjects()) {
+                //     this.remove(fabricObject);
+                // }
+                visual.getNextPathway().hide();
                 visual.getNextMidpoint().hide();
                 visual.getNextEndpoint().hide();
             }
@@ -1203,10 +1207,13 @@ export default class OpenMarchCanvas extends fabric.Canvas {
             visual.getPreviousPathway().hide();
             visual.getPreviousMidpoint().hide();
             visual.getPreviousEndpoint().hide();
-            const nextPathway = visual.getNextPathway();
-            for (const fabricObject of nextPathway.getFabricObjects()) {
-                this.remove(fabricObject);
-            }
+            // TODO: Uncomment when EditablePath is fully implemented
+            // const nextPathway = visual.getNextPathway();
+            // for (const fabricObject of nextPathway.getFabricObjects()) {
+            //     this.remove(fabricObject);
+            // }
+            // Using simple pathway method (like previous paths) for now
+            visual.getNextPathway().hide();
             visual.getNextMidpoint().hide();
             visual.getNextEndpoint().hide();
             this.requestRenderAll();


### PR DESCRIPTION
no longer render when moving marchers temporarily disable editable paths View next and previous paths properly
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added View tab toggles to show/hide previous and next path visuals on the canvas.
* Refactor
  * Streamlined path rendering for next/previous pathways to reduce flicker and improve responsiveness.
  * Standardized color updates and handling of midpoints/endpoints for consistent visuals.
* Bug Fixes
  * Path visibility now accurately reflects UI toggles during animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->