### PR TITLE
Fix for bug #885 nested sql transaction error on split page

### DIFF
--- a/apps/desktop/src/components/inspector/PageEditor.tsx
+++ b/apps/desktop/src/components/inspector/PageEditor.tsx
@@ -15,7 +15,7 @@ function PageEditor() {
     const updatePagesMutation = useMutation(
         updatePagesMutationOptions(queryClient),
     );
-    const splitPage = useSplitPage().mutate;
+    const { mutate: splitPage, isPending: isSplittingPage } = useSplitPage();
     const isFirstPage = selectedPage?.previousPageId === null;
 
     const countsInputId = "page-counts";
@@ -100,7 +100,9 @@ function PageEditor() {
                         variant="secondary"
                         size="compact"
                         onClick={() => splitPage({ page: selectedPage })}
-                        disabled={selectedPage?.beats.length <= 1}
+                        disabled={
+                            selectedPage?.beats.length <= 1 || isSplittingPage
+                        }
                     >
                         <T keyName="inspector.page.splitPage" />
                     </Button>

--- a/apps/desktop/src/components/inspector/PageEditorUtils.ts
+++ b/apps/desktop/src/components/inspector/PageEditorUtils.ts
@@ -50,7 +50,8 @@ const useSplitPageMutation = <TArgs>(
     errorKey: string,
 ) => {
     const queryClient = useQueryClient();
-    const mutation = useMutation({
+    return useMutation({
+        scope: { id: "splitPage" },
         mutationFn,
         onSuccess: async () => {
             // Invalidate all timing object queries
@@ -68,14 +69,6 @@ const useSplitPageMutation = <TArgs>(
             conToastError(tolgee.t(errorKey), error);
         },
     });
-
-    return {
-        ...mutation,
-        mutate: (...args: Parameters<typeof mutation.mutate>) => {
-            if (mutation.isPending) return; // guard to prevent multiple transactions from rapid mutation calls
-            mutation.mutate(...args);
-        },
-    };
 };
 
 // Public mutation hook

--- a/apps/desktop/src/components/inspector/PageEditorUtils.ts
+++ b/apps/desktop/src/components/inspector/PageEditorUtils.ts
@@ -50,7 +50,7 @@ const useSplitPageMutation = <TArgs>(
     errorKey: string,
 ) => {
     const queryClient = useQueryClient();
-    return useMutation({
+    const mutation = useMutation({
         mutationFn,
         onSuccess: async () => {
             // Invalidate all timing object queries
@@ -68,6 +68,14 @@ const useSplitPageMutation = <TArgs>(
             conToastError(tolgee.t(errorKey), error);
         },
     });
+
+    return {
+        ...mutation,
+        mutate: (...args: Parameters<typeof mutation.mutate>) => {
+            if (mutation.isPending) return; // guard to prevent multiple transactions from rapid mutation calls
+            mutation.mutate(...args);
+        },
+    };
 };
 
 // Public mutation hook


### PR DESCRIPTION
Fixes #885.

Added an isPending check to disable the `Spit page` button but it was still possible to trigger multiple mutations with fast enough clicking. Added a guard to the mutation function itself to prevent nested sqlite transaction errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented multiple concurrent split-page actions: the split button is now disabled while a split is in progress, stopping users from initiating another split until the current one completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->