### PR TITLE
Fix #839: await transactionWithHistory in _updateManualTempos

### DIFF
--- a/apps/desktop/src/components/music/TempoGroup/TempoGroup.ts
+++ b/apps/desktop/src/components/music/TempoGroup/TempoGroup.ts
@@ -606,7 +606,7 @@ export const _updateManualTempos = async ({
         });
     }
 
-    transactionWithHistory(db, "updateManualTempos", async (tx) => {
+    await transactionWithHistory(db, "updateManualTempos", async (tx) => {
         await updateBeatsInTransaction({
             tx,
             modifiedBeats: updatedBeats,


### PR DESCRIPTION
## Summary
- Adds missing `await` to `transactionWithHistory` call in `_updateManualTempos` in `TempoGroup.ts`
- Without `await`, the function resolved before the DB write completed, causing TanStack Query's `onSettled` invalidation to fetch stale data — so custom tempo values appeared not to refresh

## Test plan
- [ ] Open a file with custom tempo values
- [ ] Edit a manual tempo value
- [ ] Verify the updated value is reflected immediately in the UI after saving

Fixes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where music tempo updates could fail silently or not complete properly, ensuring changes are reliably applied and errors are properly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->