### PR TITLE
fix(#883): checkpoint WAL and release file locks before renaming temp DB

### DIFF
--- a/apps/desktop/electron/database/repair.ts
+++ b/apps/desktop/electron/database/repair.ts
@@ -213,17 +213,31 @@ export const repairDatabase = async (originalDbPath: string) => {
         // Remove orphaned marcher_pages entries
         removeOrphanMarcherPages(newDb);
     } catch (error) {
-        // If anything fails, delete the temp file
+        // If anything fails, close both databases and delete the temp file
+        originalDb.close();
+        try {
+            newDb.close();
+        } catch {
+            // ignore close errors during cleanup
+        }
         if (fs.existsSync(tempDbPath)) {
             fs.unlinkSync(tempDbPath);
         }
         throw error;
-    } finally {
-        // Close both databases
-        // Errors will propagate naturally, and finally ensures cleanup
-        originalDb.close();
-        newDb.close();
     }
+
+    // Checkpoint and close the new database to release all file locks before
+    // renaming. This is especially important on Windows where file locks
+    // can persist briefly after close(), causing EBUSY rename errors on
+    // network drives (e.g. OneDrive).
+    try {
+        newDb.prepare("PRAGMA wal_checkpoint(TRUNCATE)").run();
+        newDb.prepare("PRAGMA journal_mode = DELETE").run();
+    } catch {
+        // Ignore pragma errors — proceed with close
+    }
+    newDb.close();
+    originalDb.close();
 
     // If we got here, the repair was successful
     // Delete the existing FIXED file if it exists


### PR DESCRIPTION
## Summary
- `repairDatabase()` was closing both SQLite connections in a `finally` block, then renaming the temp file outside — but on Windows (especially with cloud drives like OneDrive), file locks from `newDb.close()` can persist briefly, causing `EBUSY: resource busy or locked` on the rename
- Added `PRAGMA wal_checkpoint(TRUNCATE)` and `PRAGMA journal_mode = DELETE` before closing `newDb` to flush all WAL data and clean up auxiliary files, ensuring the file lock is fully released before the rename
- Moved database close calls out of `finally` so the rename always happens after a clean close; error paths still close both databases and clean up the temp file

## Test plan
- [ ] Repair a `.dots` file — should produce a `FIXED.dots` file without errors
- [ ] (Windows) Repair a file stored on OneDrive — should no longer throw `EBUSY`
- [ ] If repair fails mid-way, the temp file should still be cleaned up

Fixes #883

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database repair robustness: better cleanup on failed repairs to prevent leftover temp files and resource locks; added checkpoint and journal reset steps on successful repairs to reduce corruption risk; non-critical errors during cleanup are now suppressed to avoid interrupting repair completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->