### PR TITLE
Fix audio file insert bindings

### DIFF
--- a/apps/desktop/electron/database/__test__/database.services.test.ts
+++ b/apps/desktop/electron/database/__test__/database.services.test.ts
@@ -1,6 +1,13 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DatabaseSync } from "node:sqlite";
-import { handleSqlProxyWithDb } from "../database.services";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+    handleSqlProxyWithDb,
+    insertAudioFile,
+    setDbPath,
+} from "../database.services";
 
 describe("Database Services", () => {
     describe("sql proxy", () => {
@@ -75,6 +82,65 @@ describe("Database Services", () => {
                 "all",
             );
             expect(result).toEqual({ rows: [] });
+        });
+    });
+
+    describe("audio files", () => {
+        let tempDir: string;
+        let dbPath: string;
+
+        beforeEach(() => {
+            tempDir = mkdtempSync(join(tmpdir(), "openmarch-audio-test-"));
+            dbPath = join(tempDir, "test.dots");
+
+            const db = new DatabaseSync(dbPath);
+            db.exec(`
+                CREATE TABLE audio_files (
+                    id INTEGER PRIMARY KEY,
+                    path TEXT NOT NULL,
+                    nickname TEXT,
+                    data BLOB,
+                    selected INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+            `);
+            db.close();
+
+            setDbPath(dbPath);
+        });
+
+        afterEach(() => {
+            setDbPath("", false);
+            rmSync(tempDir, { recursive: true, force: true });
+        });
+
+        it("should ignore non-insert fields when binding named parameters", async () => {
+            const result = await insertAudioFile({
+                id: -1,
+                data: new Uint8Array([1, 2, 3]),
+                path: "/tmp/test.mp3",
+                nickname: "test.mp3",
+                selected: true,
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.result?.[0].id).toBe(1);
+
+            const db = new DatabaseSync(dbPath);
+            const inserted = db
+                .prepare(
+                    "SELECT id, path, nickname, selected FROM audio_files WHERE id = 1",
+                )
+                .get();
+            db.close();
+
+            expect(inserted).toEqual({
+                id: 1,
+                path: "/tmp/test.mp3",
+                nickname: "test.mp3",
+                selected: 1,
+            });
         });
     });
 });

--- a/apps/desktop/electron/database/database.services.ts
+++ b/apps/desktop/electron/database/database.services.ts
@@ -454,8 +454,9 @@ export async function insertAudioFile(
                   ? audioFile.data
                   : new Uint8Array(audioFile.data);
         const insertResult = insertStmt.run({
-            ...audioFile,
             data: dataForInsert,
+            path: audioFile.path,
+            nickname: audioFile.nickname ?? null,
             selected: 1,
             created_at,
             updated_at: created_at,


### PR DESCRIPTION
## Summary
- Fix audio file import failing with `Unknown named parameter 'id'` under `node:sqlite`
- Bind only the named parameters used by the audio file INSERT statement
- Add a regression test covering insert objects that include an `id` field

## Testing
- `pnpm exec vitest run --silent=true electron/database/__test__/database.services.test.ts`
- `pnpm tsc --noEmit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded audio file insertion test coverage with improved database setup and validation.

* **Bug Fixes**
  * Fixed audio file insertion to bind only required parameters, preventing unintended field processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->