### PR TITLE
Set up Cursor Cloud dev environment + document caveats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,29 @@
 
 - `apps/desktop/src/styles/apply-tailwind-vars.cjs` is run by desktop `dev` and `build`; run `pnpm run apply-styles` manually if you need regenerated desktop style variables without starting Vite.
 - In `apps/cms`, run `pnpm run generate:types` after Payload schema changes and `pnpm run generate:importmap` after creating or modifying Payload admin components.
+
+## Cursor Cloud specific instructions
+
+The startup update script (`nvm use 24` + `corepack enable` + `pnpm install --no-frozen-lockfile`) refreshes deps. Standard build/lint/test/run commands are above; notes below are only the non-obvious caveats discovered when running each service in the cloud VM.
+
+### Toolchain
+
+- Node 24 is required. `~/.bashrc` prepends nvm's Node 24 ahead of the sandbox `/exec-daemon/node` (which is Node 22). If `node -v` ever shows v22, run `nvm use 24` (pnpm comes from corepack in the Node 24 bin).
+
+### Desktop (`pnpm desktop dev`, or `cd apps/desktop && pnpm run dev`)
+
+- Electron runs headless on `DISPLAY :1` with `--no-sandbox`. Harmless log noise: D-Bus "Failed to call method"/"Could not parse server address" lines, and an `electron-updater` "Cannot destructure property 'autoUpdater'" unhandled rejection (auto-updater is disabled in dev). None of these stop the app.
+- Single-instance lock: the app uses `app.requestSingleInstanceLock()`, so only ONE instance runs. If Electron exits immediately right after logging `Sentry error reporting enabled: false`, a stale instance/lock is blocking it — kill leftover `electron/dist/electron` PIDs and `rm -f ~/.config/OpenMarch/SingletonLock`.
+- To launch straight into the editor (skip the New File dialog), set `databasePath` in `~/.config/OpenMarch/config.json` to a `.dots` file copied from `apps/desktop/electron/database/migrations/_blank.dots`. The New File / Open File UI also works.
+- Editor `ERR_INSUFFICIENT_RESOURCES`: happens when Vite skips dependency pre-bundling because the shared-package `tsup --watch` builds (started by `pnpm desktop dev`) race Vite's dep scan. Avoid by pre-building packages (`pnpm build`, or rely on persisted `dist`) so the Vite optimizer cache at `apps/desktop/node_modules/.vite/deps` warms; running `cd apps/desktop && pnpm run dev` (no watchers) is the most reliable.
+- Electron binary gotcha: the `electron` postinstall occasionally extracts incompletely (only `dist/locales`), giving "Electron failed to install correctly". Fix once (persists in the snapshot): unzip `~/.cache/electron/<hash>/electron-*.zip` into `node_modules/.pnpm/electron@*/node_modules/electron/dist`, then `printf 'electron' > .../electron/path.txt` (NO trailing newline — `echo` breaks it).
+
+### Website (`pnpm site dev`)
+
+- Astro/Starlight on `http://localhost:4321`. Docs search (Pagefind) only works in production builds, not in dev.
+
+### CMS (`pnpm --filter @openmarch/cms dev`)
+
+- Next.js on `http://localhost:3000`; admin at `/admin`. Needs `apps/cms/.env` with a real `PAYLOAD_SECRET` (`echo PAYLOAD_SECRET="$(openssl rand -base64 64)" > apps/cms/.env`). Uses local Cloudflare bindings (D1/R2 persisted under `.wrangler/state`) — no Cloudflare login required for dev.
+- The admin renders blank ("internal-module-error … not found in importMap") until you run `pnpm --filter @openmarch/cms run generate:importmap`; the committed `importMap.js` is stale versus the Payload version pulled in by the root `pnpm.overrides` (it's a generated file, so regenerate rather than commit).
+- KNOWN PRE-EXISTING ISSUE: the Lexical rich-text Post editor errors with "Cannot destructure property 'config' … useConfig". Root `pnpm.overrides` bump `payload`/`@payloadcms/next`/`graphql`/`storage-r2` to 3.84.x while `@payloadcms/ui`/`richtext-lexical`/`db-d1-sqlite` stay at 3.73.0 (two `@payloadcms/ui` versions resolve). Admin auth, dashboard, and collection lists work, but creating/editing rich-text posts won't until the `@payloadcms/*` versions are aligned.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the OpenMarch development environment for Cursor Cloud agents and documents the non-obvious caveats discovered while running every service end to end. The only repo change is an `AGENTS.md` addition (`## Cursor Cloud specific instructions`); all dependency setup lives in the VM startup update script.

## Environment setup

- Node 24 (repo `engines`/CI) activated via `nvm`; `~/.bashrc` prepends nvm's Node 24 ahead of the sandbox's Node 22. pnpm `10.11.0` via corepack.
- Startup update script: `nvm use 24` → `corepack enable` → `pnpm install --no-frozen-lockfile`.

## Verified services

| Service | Command | Result |
| --- | --- | --- |
| Lint | `pnpm lint` | ✅ 0 errors |
| Format | `pnpm format:check` | ✅ pass |
| Spellcheck | `pnpm spellcheck` | ✅ 0 issues |
| Tests | `pnpm test` (core/musicxml/website/desktop) | ✅ 1226+ tests pass |
| Build | `pnpm build` | ✅ 7/7 tasks |
| Desktop (core product) | `pnpm desktop dev` | ✅ created file, added/placed marchers in editor |
| Website | `pnpm site dev` | ✅ homepage + docs navigation |
| CMS | `pnpm --filter @openmarch/cms dev` | ✅ admin auth + dashboard (rich-text post editor blocked by pre-existing `@payloadcms/*` version skew) |

## Hello-world demos

Desktop editor — added 8 marchers and placed them on the field (dev mode):

[Desktop editor with marchers placed on field](https://cursor.com/agents/bc-ed020872-0caa-4922-b931-555528c7567b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_dev_marchers_on_field.webp)
[openmarch_desktop_dev_add_marchers.mp4](https://cursor.com/agents/bc-ed020872-0caa-4922-b931-555528c7567b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopenmarch_desktop_dev_add_marchers.mp4)

CMS admin dashboard after creating the first admin user:

[Payload CMS dashboard](https://cursor.com/agents/bc-ed020872-0caa-4922-b931-555528c7567b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcms_dev_dashboard.webp)

Website homepage and docs:

[OpenMarch website homepage](https://cursor.com/agents/bc-ed020872-0caa-4922-b931-555528c7567b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebsite_dev_homepage.webp)

## Notable caveats documented in AGENTS.md

- Electron `postinstall` can extract incompletely → manual re-extract + `path.txt` fix.
- Single-instance lock causes Electron to exit immediately if a stale instance/lock exists.
- Editor `ERR_INSUFFICIENT_RESOURCES` from Vite skipping dep pre-bundling when `tsup --watch` races the dep scan.
- CMS admin needs `generate:importmap` to render; rich-text post editor blocked by a pre-existing `@payloadcms/*` version skew from the root `pnpm.overrides`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed020872-0caa-4922-b931-555528c7567b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed020872-0caa-4922-b931-555528c7567b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

