### PR TITLE
feat: selectable drill number for min/max step size

### DIFF
--- a/apps/desktop/src/components/inspector/MarcherEditor.tsx
+++ b/apps/desktop/src/components/inspector/MarcherEditor.tsx
@@ -561,6 +561,24 @@ function MarcherEditor() {
         marcherPages,
     ]);
 
+    const selectMaxStepMarcher = useCallback(() => {
+        if (!minMaxStepSize?.max) return;
+        setSelectedMarchers(
+            selectedMarchers.filter(
+                (marcher) => marcher.id === minMaxStepSize.max!.marcher_id,
+            ),
+        );
+    }, [minMaxStepSize, selectedMarchers, setSelectedMarchers]);
+
+    const selectMinStepMarcher = useCallback(() => {
+        if (!minMaxStepSize?.min) return;
+        setSelectedMarchers(
+            selectedMarchers.filter(
+                (marcher) => marcher.id === minMaxStepSize.min!.marcher_id,
+            ),
+        );
+    }, [minMaxStepSize, selectedMarchers, setSelectedMarchers]);
+
     const resetForm = useCallback(() => {
         coordsFormRef.current?.reset();
 
@@ -647,17 +665,7 @@ function MarcherEditor() {
                                         <div className="mt-6 flex justify-between">
                                             <button
                                                 className="text-body leading-none opacity-80 hover:underline"
-                                                onClick={() =>
-                                                    setSelectedMarchers(
-                                                        selectedMarchers.filter(
-                                                            (marcher) =>
-                                                                marcher.id ===
-                                                                minMaxStepSize!
-                                                                    .min!
-                                                                    .marcher_id,
-                                                        ),
-                                                    )
-                                                }
+                                                onClick={selectMinStepMarcher}
                                             >
                                                 {
                                                     selectedMarchers.find(
@@ -680,17 +688,7 @@ function MarcherEditor() {
                                         <div className="flex justify-between pt-6">
                                             <button
                                                 className="text-body leading-none opacity-80 hover:underline"
-                                                onClick={() =>
-                                                    setSelectedMarchers(
-                                                        selectedMarchers.filter(
-                                                            (marcher) =>
-                                                                marcher.id ===
-                                                                minMaxStepSize!
-                                                                    .max!
-                                                                    .marcher_id,
-                                                        ),
-                                                    )
-                                                }
+                                                onClick={selectMaxStepMarcher}
                                             >
                                                 {
                                                     selectedMarchers.find(

--- a/apps/desktop/src/components/inspector/MarcherEditor.tsx
+++ b/apps/desktop/src/components/inspector/MarcherEditor.tsx
@@ -423,7 +423,7 @@ function AlignmentButtons({ editingDisabled }: AlignmentButtonsProps) {
 
 // eslint-disable-next-line max-lines-per-function
 function MarcherEditor() {
-    const { selectedMarchers } = useSelectedMarchers()!;
+    const { selectedMarchers, setSelectedMarchers } = useSelectedMarchers()!;
     const selectedMarcherIds = useMemo(
         () => new Set(selectedMarchers.map((marcher) => marcher.id)),
         [selectedMarchers],
@@ -645,7 +645,20 @@ function MarcherEditor() {
                                             </p>
                                         </div>
                                         <div className="mt-6 flex justify-between">
-                                            <label className="text-body leading-none opacity-80">
+                                            <button
+                                                className="text-body leading-none opacity-80 hover:underline"
+                                                onClick={() =>
+                                                    setSelectedMarchers(
+                                                        selectedMarchers.filter(
+                                                            (marcher) =>
+                                                                marcher.id ===
+                                                                minMaxStepSize!
+                                                                    .min!
+                                                                    .marcher_id,
+                                                        ),
+                                                    )
+                                                }
+                                            >
                                                 {
                                                     selectedMarchers.find(
                                                         (marcher) =>
@@ -654,7 +667,7 @@ function MarcherEditor() {
                                                                 ?.marcher_id,
                                                     )?.drill_number
                                                 }
-                                            </label>
+                                            </button>
                                             <p className="text-body leading-none">
                                                 {minMaxStepSize.min.displayString()}
                                             </p>
@@ -665,7 +678,20 @@ function MarcherEditor() {
                                             </p>
                                         </div>
                                         <div className="flex justify-between pt-6">
-                                            <label className="text-body leading-none opacity-80">
+                                            <button
+                                                className="text-body leading-none opacity-80 hover:underline"
+                                                onClick={() =>
+                                                    setSelectedMarchers(
+                                                        selectedMarchers.filter(
+                                                            (marcher) =>
+                                                                marcher.id ===
+                                                                minMaxStepSize!
+                                                                    .max!
+                                                                    .marcher_id,
+                                                        ),
+                                                    )
+                                                }
+                                            >
                                                 {
                                                     selectedMarchers.find(
                                                         (marcher) =>
@@ -674,7 +700,7 @@ function MarcherEditor() {
                                                                 ?.marcher_id,
                                                     )?.drill_number
                                                 }
-                                            </label>
+                                            </button>
                                             <p className="text-body leading-none">
                                                 {minMaxStepSize.max.displayString()}
                                             </p>


### PR DESCRIPTION
While playing with the tool, I found myself wanting to check the pathways of marchers with the smallest/largest step size. In close proximity sets, it was difficult for me to find/select that marcher.

This PR just takes the drill number text and makes it a button, that when clicked will select that marcher so the user can see their pathways into the current set.


https://github.com/user-attachments/assets/5d09b806-cf04-47d0-9509-c5510fe0f2b7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved multi-marcher step-size navigation: the min and max step size indicators are now clickable. Selecting them updates the editor to focus on the corresponding marcher with the matching step size, making it easier to jump to specific configurations while editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->