### PR TITLE
close persistent connection when making a new file

### DIFF
--- a/apps/desktop/electron/database/__test__/database.services.test.ts
+++ b/apps/desktop/electron/database/__test__/database.services.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DatabaseSync } from "node:sqlite";
-import { mkdtempSync, rmSync } from "fs";
+import { existsSync, mkdtempSync, renameSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
+    closePersistentConnection,
+    handleSqlProxy,
     handleSqlProxyWithDb,
     insertAudioFile,
     setDbPath,
@@ -82,6 +84,41 @@ describe("Database Services", () => {
                 "all",
             );
             expect(result).toEqual({ rows: [] });
+        });
+    });
+
+    describe("persistent connection", () => {
+        let tempDir: string;
+        let dbPath: string;
+
+        beforeEach(() => {
+            tempDir = mkdtempSync(
+                join(tmpdir(), "openmarch-persistent-connection-test-"),
+            );
+            dbPath = join(tempDir, "test.dots");
+
+            const db = new DatabaseSync(dbPath);
+            db.exec("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)");
+            db.close();
+
+            setDbPath(dbPath);
+        });
+
+        afterEach(() => {
+            closePersistentConnection();
+            setDbPath("", false);
+            rmSync(tempDir, { recursive: true, force: true });
+        });
+
+        it("releases the database file so it can be renamed", async () => {
+            await handleSqlProxy(null, "SELECT 1", [], "get");
+
+            const renamedPath = join(tempDir, "renamed.dots");
+            closePersistentConnection();
+            renameSync(dbPath, renamedPath);
+
+            expect(existsSync(renamedPath)).toBe(true);
+            expect(existsSync(dbPath)).toBe(false);
         });
     });
 

--- a/apps/desktop/electron/database/database.services.ts
+++ b/apps/desktop/electron/database/database.services.ts
@@ -27,6 +27,16 @@ export class LegacyDatabaseResponse<T> {
 /* ============================ DATABASE ============================ */
 let DB_PATH = "";
 
+let persistentConnection: DatabaseSync | null = null;
+let persistentConnectionPath: string | null = null;
+
+/** Closes the long-lived SQL proxy connection so the database file can be moved or deleted. */
+export function closePersistentConnection() {
+    persistentConnection?.close();
+    persistentConnection = null;
+    persistentConnectionPath = null;
+}
+
 /**
  * Change the location of the database file the application and actively updates.
  *
@@ -59,9 +69,7 @@ export function setDbPath(path: string, isNewFile = false) {
     }
 
     // Reset any existing long-lived DB handle before opening a new path.
-    persistentConnection?.close();
-    persistentConnection = null;
-    persistentConnectionPath = null;
+    closePersistentConnection();
 
     DB_PATH = path;
     const db = connect();
@@ -272,9 +280,7 @@ export const getOrmConnection = () => {
     return getOrm(persistentConnection);
 };
 
-let persistentConnection: DatabaseSync | null = null;
-let persistentConnectionPath: string | null = null;
-async function handleSqlProxy(
+export async function handleSqlProxy(
     _: any,
     sql: string,
     params: any[],
@@ -282,9 +288,7 @@ async function handleSqlProxy(
 ) {
     try {
         if (persistentConnectionPath !== DB_PATH) {
-            persistentConnection?.close();
-            persistentConnection = null;
-            persistentConnectionPath = null;
+            closePersistentConnection();
         }
 
         if (!persistentConnection) {

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -894,11 +894,51 @@ export async function finalizeNewShowDraft(
 
     DatabaseServices.closePersistentConnection();
 
+    let backupPath: string | null = null;
     if (fs.existsSync(finalPath)) {
-        await unlinkFileWithRetry(finalPath);
+        backupPath = join(
+            finalDir,
+            `.${basename(finalPath)}.bak-${randomUUID()}`,
+        );
+        try {
+            await moveFileWithRetry(finalPath, backupPath);
+        } catch (error) {
+            console.error(
+                "Failed to backup existing show before finalize:",
+                error,
+            );
+            captureException(error);
+            return -1;
+        }
     }
 
-    await moveFileWithRetry(draftPath, finalPath);
+    try {
+        await moveFileWithRetry(draftPath, finalPath);
+    } catch (error) {
+        console.error("Failed to finalize new show draft:", error);
+        if (backupPath && fs.existsSync(backupPath)) {
+            try {
+                await moveFileWithRetry(backupPath, finalPath);
+            } catch (restoreError) {
+                console.error(
+                    "Failed to restore show backup after finalize failure:",
+                    restoreError,
+                );
+                captureException(restoreError);
+            }
+        }
+        captureException(error);
+        return -1;
+    }
+
+    if (backupPath) {
+        try {
+            await unlinkFileWithRetry(backupPath);
+        } catch {
+            // best-effort cleanup
+        }
+    }
+
     currentNewShowDraftPath = null;
 
     await setActiveDb(finalPath, false);

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -810,6 +810,65 @@ function resolveFinalizeTargetPath(
     return trimmed;
 }
 
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function moveFileWithRetry(source: string, dest: string): Promise<void> {
+    const resolvedSource = resolve(source);
+    const resolvedDest = resolve(dest);
+    const maxAttempts = 5;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+            fs.renameSync(resolvedSource, resolvedDest);
+            return;
+        } catch (err: unknown) {
+            const code =
+                err && typeof err === "object" && "code" in err
+                    ? (err as NodeJS.ErrnoException).code
+                    : undefined;
+
+            if (code === "EXDEV") {
+                fs.copyFileSync(resolvedSource, resolvedDest);
+                fs.unlinkSync(resolvedSource);
+                return;
+            }
+
+            if (code === "EBUSY" && attempt < maxAttempts - 1) {
+                await sleep(25 * (attempt + 1));
+                continue;
+            }
+
+            throw err;
+        }
+    }
+}
+
+async function unlinkFileWithRetry(filePath: string): Promise<void> {
+    const resolvedPath = resolve(filePath);
+    const maxAttempts = 5;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+            fs.unlinkSync(resolvedPath);
+            return;
+        } catch (err: unknown) {
+            const code =
+                err && typeof err === "object" && "code" in err
+                    ? (err as NodeJS.ErrnoException).code
+                    : undefined;
+
+            if (code === "EBUSY" && attempt < maxAttempts - 1) {
+                await sleep(25 * (attempt + 1));
+                continue;
+            }
+
+            throw err;
+        }
+    }
+}
+
 /**
  * Moves the draft file to the user's chosen path and reloads into the editor.
  */
@@ -819,29 +878,27 @@ export async function finalizeNewShowDraft(
 ): Promise<number> {
     if (!currentNewShowDraftPath || !win) return -1;
 
-    const draftPath = currentNewShowDraftPath;
-    const finalPath = projectName
-        ? resolveFinalizeTargetPath(projectName, targetPath)
-        : targetPath.endsWith(".dots")
-          ? targetPath
-          : `${targetPath}.dots`;
+    const draftPath = resolve(currentNewShowDraftPath);
+    const finalPath = resolve(
+        projectName
+            ? resolveFinalizeTargetPath(projectName, targetPath)
+            : targetPath.endsWith(".dots")
+              ? targetPath
+              : `${targetPath}.dots`,
+    );
 
     const finalDir = dirname(finalPath);
     if (!fs.existsSync(finalDir)) {
         fs.mkdirSync(finalDir, { recursive: true });
     }
 
-    try {
-        DatabaseServices.connect()?.close();
-    } catch {
-        // ignore close errors
-    }
+    DatabaseServices.closePersistentConnection();
 
     if (fs.existsSync(finalPath)) {
-        fs.unlinkSync(finalPath);
+        await unlinkFileWithRetry(finalPath);
     }
 
-    fs.renameSync(draftPath, finalPath);
+    await moveFileWithRetry(draftPath, finalPath);
     currentNewShowDraftPath = null;
 
     await setActiveDb(finalPath, false);
@@ -854,19 +911,16 @@ export async function finalizeNewShowDraft(
  * Deletes the draft file and clears the DB connection without reloading.
  */
 export async function discardNewShowDraft(): Promise<number> {
-    const draftPath = currentNewShowDraftPath;
+    const draftPath = currentNewShowDraftPath
+        ? resolve(currentNewShowDraftPath)
+        : null;
     currentNewShowDraftPath = null;
 
     if (!draftPath) {
         return 200;
     }
 
-    try {
-        DatabaseServices.connect()?.close();
-    } catch {
-        // ignore
-    }
-
+    DatabaseServices.closePersistentConnection();
     DatabaseServices.setDbPath("", false);
 
     const storedPath = store.get("databasePath") as string | undefined;
@@ -875,7 +929,7 @@ export async function discardNewShowDraft(): Promise<number> {
     }
 
     if (fs.existsSync(draftPath)) {
-        fs.unlinkSync(draftPath);
+        await unlinkFileWithRetry(draftPath);
     }
 
     return 200;

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
     "name": "@openmarch/desktop",
     "productName": "OpenMarch",
     "description": "Free drill-writing software for the marching arts",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "main": "dist-electron/main/index.js",
     "author": "OpenMarch LLC <contact@openmarch.com>",
     "url": "https://openmarch.com",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved draft handling to better recover from file lock and cross-device move errors.
  * Draft finalization and discard actions are now more reliable and less likely to fail unexpectedly.
  * Database connections are now closed more consistently when switching or cleaning up drafts.

* **Chores**
  * Updated the desktop app and website version to `0.1.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->