### PR TITLE
delete marcher pages when page deletes

### DIFF
--- a/apps/desktop/src/db-functions/__test__/page.test.ts
+++ b/apps/desktop/src/db-functions/__test__/page.test.ts
@@ -18,7 +18,18 @@ import {
 } from "../page";
 import { describeDbTests, schema, transaction } from "@/test/base";
 import { getTestWithHistory } from "@/test/history";
-import { inArray, desc, eq, and, gte, lte, asc, isNotNull } from "drizzle-orm";
+import {
+    inArray,
+    desc,
+    eq,
+    and,
+    gte,
+    lte,
+    asc,
+    isNotNull,
+    sql,
+    count,
+} from "drizzle-orm";
 import {
     FIRST_BEAT_ID,
     NewBeatArgs,
@@ -1729,6 +1740,67 @@ describeDbTests("pages", (it) => {
 
     describe("createLastPage", () => {
         describe("with existing pages", () => {
+            testWithHistory(
+                "creates a page when stale marcher pages exist for the reused page id",
+                async ({ db }) => {
+                    const newPageCounts = 8;
+                    const firstCreatedPage = await createLastPage({
+                        db,
+                        newPageCounts,
+                        createNewBeats: true,
+                    });
+                    const marcherCount = await db
+                        .select({ count: count() })
+                        .from(schema.marchers)
+                        .get();
+                    assert(marcherCount != null, "Marcher count not found");
+
+                    await db.run(sql.raw("PRAGMA foreign_keys = OFF"));
+                    await db
+                        .delete(schema.pages)
+                        .where(eq(schema.pages.id, firstCreatedPage.id));
+                    await db.run(sql.raw("PRAGMA foreign_keys = ON"));
+
+                    const staleMarcherPages = await db
+                        .select({ count: count() })
+                        .from(schema.marcher_pages)
+                        .where(
+                            eq(
+                                schema.marcher_pages.page_id,
+                                firstCreatedPage.id,
+                            ),
+                        )
+                        .get();
+                    expect(staleMarcherPages?.count).toBe(marcherCount.count);
+
+                    const secondCreatedPage = await createLastPage({
+                        db,
+                        newPageCounts,
+                        createNewBeats: true,
+                    });
+
+                    expect(secondCreatedPage.id).toBe(firstCreatedPage.id);
+                    const recreatedMarcherPages = await db
+                        .select({ count: count() })
+                        .from(schema.marcher_pages)
+                        .where(
+                            eq(
+                                schema.marcher_pages.page_id,
+                                secondCreatedPage.id,
+                            ),
+                        )
+                        .get();
+                    expect(recreatedMarcherPages?.count).toBe(
+                        marcherCount.count,
+                    );
+
+                    const foreignKeyFailures = await db.all(
+                        sql.raw("PRAGMA foreign_key_check"),
+                    );
+                    expect(foreignKeyFailures).toEqual([]);
+                },
+            );
+
             testWithHistory.for([
                 {
                     newPageCounts: 8,

--- a/apps/desktop/src/db-functions/page.ts
+++ b/apps/desktop/src/db-functions/page.ts
@@ -294,6 +294,11 @@ export const createPagesInTransaction = async ({
             pageBeatMap.get(a.id)!.position - pageBeatMap.get(b.id)!.position,
     );
 
+    const createdPageIds = createdPages.map((page) => page.id);
+    await tx
+        .delete(schema.marcher_pages)
+        .where(inArray(schema.marcher_pages.page_id, createdPageIds));
+
     await _createMarcherPages({
         tx,
         sortedNewPages,
@@ -535,6 +540,10 @@ export const deletePagesInTransaction = async ({
         lastPageBeforeDeletion != null,
         "Last page before deletion not found",
     );
+
+    await tx
+        .delete(schema.marcher_pages)
+        .where(inArray(schema.marcher_pages.page_id, Array.from(pageIds)));
 
     const deletedPages = await tx
         .delete(schema.pages)


### PR DESCRIPTION
fix #963 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed page creation and deletion so related page content is cleaned up and rebuilt correctly when page IDs are reused.
  * Prevented stale page-related records from lingering after deletes, reducing the chance of inconsistent data.
  * Added coverage for reused page IDs to confirm the data remains valid and no database integrity issues are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->