### PR TITLE
Repair function repairs a copy of the file

### DIFF
--- a/apps/desktop/electron/database/__test__/repair.test.ts
+++ b/apps/desktop/electron/database/__test__/repair.test.ts
@@ -18,6 +18,7 @@ import { runInSqliteTransaction } from "@/test/sqliteTransaction";
 
 describe("DatabaseSync Repair", () => {
     let tempDir: string;
+    let userDataDir: string;
 
     beforeEach(() => {
         // Mock app.getAppPath to return the correct path for tests
@@ -36,6 +37,13 @@ describe("DatabaseSync Repair", () => {
 
         // Create a temporary directory for test databases
         tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "repair-test-"));
+        userDataDir = path.join(tempDir, "userData");
+        vi.mocked(app.getPath as (name: string) => string).mockImplementation(
+            (name: string) => {
+                if (name === "userData") return userDataDir;
+                return tempDir;
+            },
+        );
         // Mock console methods to reduce noise in test output
         vi.spyOn(console, "log").mockImplementation(() => {});
         vi.spyOn(console, "debug").mockImplementation(() => {});
@@ -45,11 +53,7 @@ describe("DatabaseSync Repair", () => {
     afterEach(() => {
         // Clean up temporary files and directories
         try {
-            const files = fs.readdirSync(tempDir);
-            for (const file of files) {
-                fs.unlinkSync(path.join(tempDir, file));
-            }
-            fs.rmdirSync(tempDir);
+            fs.rmSync(tempDir, { recursive: true, force: true });
         } catch (error) {
             // Ignore cleanup errors
         }
@@ -65,6 +69,13 @@ describe("DatabaseSync Repair", () => {
             setupFn(db);
         }
         return db;
+    };
+
+    const getRepairTempEntries = () => {
+        const repairTempRoot = path.join(userDataDir, "repair-temp");
+        return fs.existsSync(repairTempRoot)
+            ? fs.readdirSync(repairTempRoot)
+            : [];
     };
 
     const createNewDatabaseWithMigrations = async (
@@ -1037,6 +1048,34 @@ describe("DatabaseSync Repair", () => {
 
             // Temp file should be cleaned up by the time repair completes
             expect(fs.existsSync(tempDbPath)).toBe(false);
+            expect(getRepairTempEntries()).toHaveLength(0);
+            expect(fs.existsSync(fixedPath)).toBe(true);
+
+            fs.unlinkSync(fixedPath);
+            fs.unlinkSync(originalDbPath);
+        });
+
+        it("should clean up the app data repair workspace after using it", async () => {
+            const originalDbPath = path.join(tempDir, "test.dots");
+            const originalDb = await createTestDatabase(
+                originalDbPath,
+                (db) => {
+                    db.exec(`
+                    CREATE TABLE field_properties (id INTEGER PRIMARY KEY CHECK (id = 1), json_data TEXT NOT NULL);
+                    INSERT INTO field_properties (id, json_data) VALUES (1, '{"test": "data"}');
+                    CREATE TABLE utility (id INTEGER PRIMARY KEY CHECK (id = 0), last_page_counts INTEGER);
+                    INSERT INTO utility (id, last_page_counts) VALUES (0, 8);
+                    CREATE TABLE workspace_settings (id INTEGER PRIMARY KEY CHECK (id = 1), json_data TEXT NOT NULL);
+                    INSERT INTO workspace_settings (id, json_data) VALUES (1, '{}');
+                `);
+                },
+            );
+            originalDb.close();
+
+            const fixedPath = await repairDatabase(originalDbPath);
+
+            expect(fixedPath).toBe(path.join(tempDir, "test - FIXED.dots"));
+            expect(getRepairTempEntries()).toHaveLength(0);
             expect(fs.existsSync(fixedPath)).toBe(true);
 
             fs.unlinkSync(fixedPath);
@@ -1090,6 +1129,7 @@ describe("DatabaseSync Repair", () => {
 
             // Temp file should be cleaned up even on failure
             expect(fs.existsSync(tempDbPath)).toBe(false);
+            expect(getRepairTempEntries()).toHaveLength(0);
 
             if (fs.existsSync(originalDbPath)) {
                 fs.unlinkSync(originalDbPath);

--- a/apps/desktop/electron/database/repair.ts
+++ b/apps/desktop/electron/database/repair.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { randomUUID } from "crypto";
 import * as fs from "fs";
 import * as path from "path";
 import { app } from "electron";
@@ -202,62 +203,67 @@ export const removeOrphanMarcherPages = (db: DatabaseSync): void => {
 export const repairDatabase = async (originalDbPath: string) => {
     // 1. Create paths for temp and final database files
     const originalPathObj = path.parse(originalDbPath);
-    const tempDbPath = path.join(
-        originalPathObj.dir,
-        `${originalPathObj.name}${originalPathObj.ext}.temp`,
+    const repairTempDir = path.join(
+        app.getPath("userData"),
+        "repair-temp",
+        randomUUID(),
     );
+    fs.mkdirSync(repairTempDir, { recursive: true });
+
+    const sourceDbPath = path.join(
+        repairTempDir,
+        path.basename(originalDbPath),
+    );
+    const tempDbPath = path.join(repairTempDir, "repaired.dots.temp");
     const finalDbPath = path.join(
         originalPathObj.dir,
         `${originalPathObj.name} - FIXED${originalPathObj.ext}`,
     );
 
-    // Delete the temp database if it already exists
-    if (fs.existsSync(tempDbPath)) {
-        fs.unlinkSync(tempDbPath);
-    }
-
-    // Open the original database
-    const originalDb = new DatabaseSync(originalDbPath, { readOnly: true });
-
-    // Create the new database at the temp path
-    const newDb = new DatabaseSync(tempDbPath);
+    let originalDb: DatabaseSync | undefined;
+    let newDb: DatabaseSync | undefined;
 
     try {
-        // Initialize and run migrations on the new database
-        await initializeAndMigrateDatabase(newDb);
+        fs.copyFileSync(originalDbPath, sourceDbPath);
 
-        // Turn off foreign keys for data copying
-        newDb.prepare("PRAGMA foreign_keys = OFF").run();
+        // Open the copied source database so repair does not hold the active file.
+        originalDb = new DatabaseSync(sourceDbPath, { readOnly: true });
 
-        // Copy data from original database
-        copyDataFromOriginalDatabase(originalDb, newDb, originalDbPath);
+        // Create the new database at the temp path in the app data directory.
+        newDb = new DatabaseSync(tempDbPath);
 
-        // Turn foreign keys back on
-        newDb.prepare("PRAGMA foreign_keys = ON").run();
+        try {
+            // Initialize and run migrations on the new database
+            await initializeAndMigrateDatabase(newDb);
 
-        // Remove orphaned marcher_pages entries
-        removeOrphanMarcherPages(newDb);
-    } catch (error) {
-        // If anything fails, delete the temp file
-        if (fs.existsSync(tempDbPath)) {
-            fs.unlinkSync(tempDbPath);
+            // Turn off foreign keys for data copying
+            newDb.prepare("PRAGMA foreign_keys = OFF").run();
+
+            // Copy data from original database
+            copyDataFromOriginalDatabase(originalDb, newDb, sourceDbPath);
+
+            // Turn foreign keys back on
+            newDb.prepare("PRAGMA foreign_keys = ON").run();
+
+            // Remove orphaned marcher_pages entries
+            removeOrphanMarcherPages(newDb);
+        } finally {
+            // Close both databases before moving or deleting temp files.
+            originalDb?.close();
+            newDb?.close();
         }
-        throw error;
+
+        // If we got here, the repair was successful
+        // Delete the existing FIXED file if it exists
+        if (fs.existsSync(finalDbPath)) {
+            fs.unlinkSync(finalDbPath);
+        }
+
+        // Rename the temp file to the final name
+        fs.renameSync(tempDbPath, finalDbPath);
+
+        return finalDbPath;
     } finally {
-        // Close both databases
-        // Errors will propagate naturally, and finally ensures cleanup
-        originalDb.close();
-        newDb.close();
+        fs.rmSync(repairTempDir, { recursive: true, force: true });
     }
-
-    // If we got here, the repair was successful
-    // Delete the existing FIXED file if it exists
-    if (fs.existsSync(finalDbPath)) {
-        fs.unlinkSync(finalDbPath);
-    }
-
-    // Rename the temp file to the final name
-    fs.renameSync(tempDbPath, finalDbPath);
-
-    return finalDbPath;
 };

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -365,6 +365,7 @@ function initDatabaseIpcHandlers() {
     ipcMain.handle("newShow:getDraftPath", () => currentNewShowDraftPath);
     ipcMain.handle("database:repair", async (_, dbPath: string) => {
         try {
+            DatabaseServices.closePersistentConnection();
             const newPath = await repairDatabase(dbPath);
             await setActiveDb(newPath);
             return newPath;


### PR DESCRIPTION
Fixes a bug where users could not repair the database file. This seemed to happen on windows due to a locked file.

Mentioned in #963