### PR TITLE
switch website to use static assets

### DIFF
--- a/apps/desktop/electron-builder.json5
+++ b/apps/desktop/electron-builder.json5
@@ -18,10 +18,11 @@
         "electron/database/migrations",
         "!**/node_modules/canvas/**",
     ],
-    artifactName: "${productName}_${buildVersion}-${platform}_${arch}.${ext}",
+    artifactName: "${productName}-${platform}-${arch}.${ext}",
 
     mac: {
         target: ["dmg", "zip"],
+        artifactName: "${productName}-macos-${arch}.${ext}",
         hardenedRuntime: true,
         gatekeeperAssess: true,
         darkModeSupport: true,
@@ -69,7 +70,7 @@
     },
     win: {
         target: "nsis",
-        artifactName: "${productName}_${buildVersion}.${ext}",
+        artifactName: "${productName}-windows.${ext}",
         // Note: Azure signing is configured in electron-builder-sign.json5
         // which extends this config and is only used for signed releases
         fileAssociations: [
@@ -93,6 +94,7 @@
 
     linux: {
         target: ["snap", "AppImage"],
+        artifactName: "${productName}-linux-${arch}.${ext}",
         category: "Graphics",
         synopsis: "OpenMarch is an open source drill writing software built on web app frameworks. Our goal is to be a free and easy drill writing solution for marching bands, indoor programs, and applicable performing ensembles. OpenMarch hopes to be enough for 90% of ensembles with reasonable design needs. We want to make drill writing effortless. OpenMarch is designed with three principles: stay free, stay fast, and stay simple.\nOpenMarch is designed with three principles:\n\tStay free - All of the technologies OpenMarch uses have been intentionally chosen to minimize operation costs. This ensures that OpenMarch remains accessible to everyone, regardless of their financial situation.\n\tStay fast - OpenMarch is built with performance in mind. We want to ensure that the software runs smoothly on any device, making the drill writing process efficient and enjoyable.\n\tStay simple - We focus on providing essential features without unnecessary complexity. Our interface is intuitive and easy to use, allowing you to create drill without a steep learning curve.",
         fileAssociations: [

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
     "name": "@openmarch/desktop",
     "productName": "OpenMarch",
     "description": "Free drill-writing software for the marching arts",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "main": "dist-electron/main/index.js",
     "author": "OpenMarch LLC <contact@openmarch.com>",
     "url": "https://openmarch.com",

--- a/apps/website/src/components/download/DownloadCards.tsx
+++ b/apps/website/src/components/download/DownloadCards.tsx
@@ -8,8 +8,10 @@ import {
     DialogClose,
 } from "@openmarch/ui";
 import { LogoWindows, LogoMacOS, LogoLinux } from "@/components/Logos";
-import { CURRENT_VERSION } from "@/constants";
 import { HeartIcon } from "@phosphor-icons/react";
+
+const LATEST_RELEASE_DOWNLOAD_URL =
+    "https://github.com/OpenMarch/OpenMarch/releases/latest/download";
 
 export default function DownloadCards() {
     const [donationDialogOpen, setDonationDialogOpen] = useState(false);
@@ -30,7 +32,7 @@ export default function DownloadCards() {
                     <h1 className="text-h1 max-[520px]:text-h2">Windows</h1>
                     <div className="flex flex-wrap gap-12">
                         <a
-                            href={`https://github.com/OpenMarch/OpenMarch/releases/download/${CURRENT_VERSION}/OpenMarch_${CURRENT_VERSION.substring(1)}.exe`}
+                            href={`${LATEST_RELEASE_DOWNLOAD_URL}/OpenMarch-windows.exe`}
                             onClick={handleDownloadClick}
                             download
                         >
@@ -45,7 +47,7 @@ export default function DownloadCards() {
                     <h1 className="text-h1 max-[520px]:text-h2">macOS</h1>
                     <div className="flex flex-col items-center justify-center gap-12">
                         <a
-                            href={`https://github.com/OpenMarch/OpenMarch/releases/download/${CURRENT_VERSION}/OpenMarch_${CURRENT_VERSION.substring(1)}-darwin_arm64.dmg`}
+                            href={`${LATEST_RELEASE_DOWNLOAD_URL}/OpenMarch-macos-arm64.dmg`}
                             onClick={handleDownloadClick}
                             download
                         >
@@ -54,7 +56,7 @@ export default function DownloadCards() {
                             </Button>
                         </a>
                         <a
-                            href={`https://github.com/OpenMarch/OpenMarch/releases/download/${CURRENT_VERSION}/OpenMarch_${CURRENT_VERSION.substring(1)}-darwin_x64.dmg`}
+                            href={`${LATEST_RELEASE_DOWNLOAD_URL}/OpenMarch-macos-x64.dmg`}
                             onClick={handleDownloadClick}
                             download
                         >
@@ -71,7 +73,7 @@ export default function DownloadCards() {
                     <h1 className="text-h1 max-[520px]:text-h2">Linux</h1>
                     <div className="flex flex-col items-center justify-center gap-12">
                         <a
-                            href={`https://github.com/OpenMarch/OpenMarch/releases/download/${CURRENT_VERSION}/OpenMarch_${CURRENT_VERSION.substring(1)}-linux_x86_64.AppImage`}
+                            href={`${LATEST_RELEASE_DOWNLOAD_URL}/OpenMarch-linux-x64.AppImage`}
                             onClick={handleDownloadClick}
                             download
                         >
@@ -80,7 +82,7 @@ export default function DownloadCards() {
                             </Button>
                         </a>
                         <a
-                            href={`https://github.com/OpenMarch/OpenMarch/releases/download/${CURRENT_VERSION}/OpenMarch_${CURRENT_VERSION.substring(1)}-linux_arm64.AppImage`}
+                            href={`${LATEST_RELEASE_DOWNLOAD_URL}/OpenMarch-linux-arm64.AppImage`}
                             onClick={handleDownloadClick}
                             download
                         >

--- a/apps/website/src/components/download/GithubReleases.tsx
+++ b/apps/website/src/components/download/GithubReleases.tsx
@@ -236,18 +236,36 @@ export default function GithubReleases() {
                                                           />
                                                           {asset.name.includes(
                                                               "darwin_arm64",
+                                                          ) ||
+                                                          asset.name.includes(
+                                                              "darwin-arm64",
+                                                          ) ||
+                                                          asset.name.includes(
+                                                              "macos-arm64",
                                                           )
                                                               ? "Apple Silicon"
                                                               : asset.name.includes(
                                                                       "darwin_x64",
+                                                                  ) ||
+                                                                  asset.name.includes(
+                                                                      "darwin-x64",
+                                                                  ) ||
+                                                                  asset.name.includes(
+                                                                      "macos-x64",
                                                                   )
                                                                 ? "Intel Mac"
                                                                 : asset.name.includes(
                                                                         "linux_x86_64",
+                                                                    ) ||
+                                                                    asset.name.includes(
+                                                                        "linux-x64",
                                                                     )
                                                                   ? "Linux x64 .AppImage"
                                                                   : asset.name.includes(
                                                                           "linux_arm64",
+                                                                      ) ||
+                                                                      asset.name.includes(
+                                                                          "linux-arm64",
                                                                       )
                                                                     ? "Linux ARM .AppImage"
                                                                     : asset.name.includes(

--- a/apps/website/src/components/home/Landing.astro
+++ b/apps/website/src/components/home/Landing.astro
@@ -1,7 +1,6 @@
 ---
 import { Image } from "astro:assets";
 import { Badge, Button } from "@openmarch/ui";
-import { CURRENT_VERSION } from "@/constants";
 import fullscreenDark from "@/assets/desktop/perdark.png";
 import fullscreenLight from "@/assets/desktop/perlight.png";
 import editorDark from "@/assets/desktop/landerdark.png";
@@ -12,11 +11,6 @@ import editorLight from "@/assets/desktop/landerlight.png";
     id="landing"
     class="relative flex h-fit flex-col min-w-0 w-full items-center justify-center gap-16 border border-stroke pt-32 pb-8 px-8 rounded-[14px]"
 >
-    {
-        /*<code class="font-mono text-h4 text-accent motion-delay-100"
-        >{CURRENT_VERSION}</code
-    > */
-    }
     <a href="/mobile"
         ><Badge variant="secondary"
             ><span class="text-accent">New:</span> On The Move Mobile App</Badge

--- a/apps/website/src/constants.ts
+++ b/apps/website/src/constants.ts
@@ -1,5 +1,3 @@
-export const CURRENT_VERSION = "v0.1.2";
-
 export const APP_STORE_URL =
     "https://apps.apple.com/us/app/openmarch-on-the-move/id6761351662";
 export const PLAY_STORE_URL =


### PR DESCRIPTION
## Problem 
We constantly need to change the version number for the desktop app on the website

## Solution
- Make the release assets have static names. I.e. no `version_number` in the middle of them 
  - E.g. `openmarch-windows.exe` rather than `openmarch-windows-0.1.2.exe`
- Change the download link to use `/releases/latest`
- Old download versions still use the new link

**NOTE** - this should not go into effect until we make a new release with the new naming scheme


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download buttons now link directly to the latest desktop release assets for all supported platforms.

* **Bug Fixes**
  * Improved download asset naming and platform labeling for macOS, Windows, and Linux to better match the correct files (including additional filename variants).
  * Updated desktop packaging artifact naming to use a consistent cross-platform format.

* **Documentation**
  * Removed the version badge from the landing page for a cleaner homepage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->