### PR TITLE
Yank option for deleting pages

### DIFF
--- a/apps/desktop/e2e/tests/pages.spec.mts
+++ b/apps/desktop/e2e/tests/pages.spec.mts
@@ -1,5 +1,26 @@
 import { test } from "../fixtures.mjs";
 import { expect, type Page } from "playwright/test";
+import fs from "fs-extra";
+import initSqlJs from "sql.js";
+
+const getPageStartPositions = async (databasePath: string) => {
+    const SQL = await initSqlJs({
+        locateFile: (file: string) => `./node_modules/sql.js/dist/${file}`,
+    });
+    const db = new SQL.Database(fs.readFileSync(databasePath));
+    const result = db.exec(`
+        SELECT pages.id, beats.position
+        FROM pages
+        INNER JOIN beats ON pages.start_beat = beats.id
+        ORDER BY beats.position ASC
+    `);
+    db.close();
+
+    return (result[0]?.values ?? []).map(([id, position]) => ({
+        id: Number(id),
+        position: Number(position),
+    }));
+};
 
 export const createNewPage = async (page: Page) => {
     const pagesTextBefore = (await page.locator("#pages").textContent()) ?? "";
@@ -184,7 +205,7 @@ test("Delete page", async ({ electronApp }) => {
     await page.locator("div").filter({ hasText: /^3$/ }).first().click({
         button: "right",
     });
-    await page.getByRole("button").click();
+    await page.getByRole("button", { name: "In Place" }).click();
     for (const pageName of ["0", "1", "2"])
         await expect(page.locator("#pages")).toContainText(pageName);
     await expect(page.locator("#pages")).not.toContainText("3");
@@ -194,8 +215,47 @@ test("Delete page", async ({ electronApp }) => {
     await page.locator("div").filter({ hasText: /^1$/ }).first().click({
         button: "right",
     });
-    await page.getByRole("button").click();
+    await page.getByRole("button", { name: "In Place" }).click();
     for (const pageName of ["0", "1"]) // page is renamed to 1
         await expect(page.locator("#pages")).toContainText(pageName);
     await expect(page.locator("#pages")).not.toContainText("2");
+});
+
+test("Delete page with yank", async ({ electronApp }) => {
+    const { databasePath, page } = electronApp;
+
+    await createNewPage(page);
+    await createNewPage(page);
+    await createNewPage(page);
+    await createNewPage(page);
+
+    for (const pageName of ["0", "1", "2", "3", "4"])
+        await expect(page.locator("#pages")).toContainText(pageName);
+
+    const positionsBeforeDelete = await getPageStartPositions(databasePath);
+    expect(positionsBeforeDelete.length).toBe(5);
+
+    const pageToDelete = positionsBeforeDelete[2];
+    const nextPage = positionsBeforeDelete[3];
+    const yankLength = nextPage.position - pageToDelete.position;
+
+    await page.locator("div").filter({ hasText: /^2$/ }).first().click();
+    await page.locator("div").filter({ hasText: /^2$/ }).first().click({
+        button: "right",
+    });
+    await page.getByRole("button", { name: "Yank" }).click();
+
+    await expect(page.locator("#pages")).not.toContainText("4");
+    for (const pageName of ["0", "1", "2", "3"])
+        await expect(page.locator("#pages")).toContainText(pageName);
+
+    await expect
+        .poll(() => getPageStartPositions(databasePath))
+        .toEqual([
+            ...positionsBeforeDelete.slice(0, 2),
+            ...positionsBeforeDelete.slice(3).map((pagePosition) => ({
+                ...pagePosition,
+                position: pagePosition.position - yankLength,
+            })),
+        ]);
 });

--- a/apps/desktop/i18n/en.json
+++ b/apps/desktop/i18n/en.json
@@ -1101,7 +1101,11 @@
         },
         "page": {
             "contextMenu": {
-                "deletePage": "Delete",
+                "delete": "Delete",
+                "deleteInPlace": "In Place",
+                "deleteInPlaceTooltip": "Delete this page and keep later pages where they are.",
+                "deleteYank": "Yank",
+                "deleteYankTooltip": "Delete this page and pull later pages back by its length.",
                 "subsetToggle": "Subset",
                 "title": "Page {pageName}"
             },

--- a/apps/desktop/i18n/es.json
+++ b/apps/desktop/i18n/es.json
@@ -861,7 +861,11 @@
         },
         "page": {
             "contextMenu": {
-                "deletePage": "Eliminar",
+                "delete": "Eliminar",
+                "deleteInPlace": "En sitio",
+                "deleteInPlaceTooltip": "Elimina esta página y deja las páginas posteriores donde están.",
+                "deleteYank": "Tirar",
+                "deleteYankTooltip": "Elimina esta página y mueve las páginas posteriores hacia atrás por su longitud.",
                 "subsetToggle": "Subconjunto",
                 "title": "Página {pageName}"
             },

--- a/apps/desktop/i18n/fr.json
+++ b/apps/desktop/i18n/fr.json
@@ -861,7 +861,11 @@
         },
         "page": {
             "contextMenu": {
-                "deletePage": "Supprimer",
+                "delete": "Supprimer",
+                "deleteInPlace": "Sur place",
+                "deleteInPlaceTooltip": "Supprime cette page et garde les pages suivantes a leur position.",
+                "deleteYank": "Tirer",
+                "deleteYankTooltip": "Supprime cette page et recule les pages suivantes de sa longueur.",
                 "subsetToggle": "Sous-ensemble",
                 "title": "Page {pageName}"
             },

--- a/apps/desktop/i18n/fr.json
+++ b/apps/desktop/i18n/fr.json
@@ -863,7 +863,7 @@
             "contextMenu": {
                 "delete": "Supprimer",
                 "deleteInPlace": "Sur place",
-                "deleteInPlaceTooltip": "Supprime cette page et garde les pages suivantes a leur position.",
+                "deleteInPlaceTooltip": "Supprime cette page et garde les pages suivantes à leur position.",
                 "deleteYank": "Tirer",
                 "deleteYankTooltip": "Supprime cette page et recule les pages suivantes de sa longueur.",
                 "subsetToggle": "Sous-ensemble",

--- a/apps/desktop/i18n/ja.json
+++ b/apps/desktop/i18n/ja.json
@@ -845,7 +845,11 @@
         },
         "page": {
             "contextMenu": {
-                "deletePage": "ページを削除",
+                "delete": "削除",
+                "deleteInPlace": "その場",
+                "deleteInPlaceTooltip": "このページを削除し、後続ページの位置はそのままにします。",
+                "deleteYank": "ヤンク",
+                "deleteYankTooltip": "このページを削除し、その長さ分だけ後続ページを前に詰めます。",
                 "subsetToggle": "サブセット",
                 "title": "ページ {pageName}"
             },

--- a/apps/desktop/i18n/pt-BR.json
+++ b/apps/desktop/i18n/pt-BR.json
@@ -847,9 +847,9 @@
             "contextMenu": {
                 "delete": "Excluir",
                 "deleteInPlace": "No lugar",
-                "deleteInPlaceTooltip": "Exclui esta pagina e mantem as paginas seguintes onde estao.",
+                "deleteInPlaceTooltip": "Exclui esta página e mantém as páginas seguintes onde estão.",
                 "deleteYank": "Puxar",
-                "deleteYankTooltip": "Exclui esta pagina e puxa as paginas seguintes para tras pelo seu comprimento.",
+                "deleteYankTooltip": "Exclui esta página e puxa as páginas seguintes para trás pelo seu comprimento.",
                 "subsetToggle": "Subconjunto",
                 "title": "Página {pageName}"
             },

--- a/apps/desktop/i18n/pt-BR.json
+++ b/apps/desktop/i18n/pt-BR.json
@@ -845,7 +845,11 @@
         },
         "page": {
             "contextMenu": {
-                "deletePage": "Excluir",
+                "delete": "Excluir",
+                "deleteInPlace": "No lugar",
+                "deleteInPlaceTooltip": "Exclui esta pagina e mantem as paginas seguintes onde estao.",
+                "deleteYank": "Puxar",
+                "deleteYankTooltip": "Exclui esta pagina e puxa as paginas seguintes para tras pelo seu comprimento.",
                 "subsetToggle": "Subconjunto",
                 "title": "Página {pageName}"
             },

--- a/apps/desktop/src/components/timeline/PageTimeline.tsx
+++ b/apps/desktop/src/components/timeline/PageTimeline.tsx
@@ -8,11 +8,12 @@ import Page, { updatePageCountRequest } from "@/global/classes/Page";
 import clsx from "clsx";
 import { durationToBeats } from "@/global/classes/Beat";
 import * as ContextMenu from "@radix-ui/react-context-menu";
-import { Button, Switch, TooltipClassName } from "@openmarch/ui";
+import { Switch, TooltipClassName } from "@openmarch/ui";
 import { useFullscreenStore } from "@/stores/FullscreenStore";
 import { T, useTolgee } from "@tolgee/react";
 import * as ToolTip from "@radix-ui/react-tooltip";
 import {
+    deletePageYankMutationOptions,
     deletePagesMutationOptions,
     ModifyPagesRequest,
     updatePagesMutationOptions,
@@ -38,6 +39,9 @@ export default function PageTimeline() {
     );
     const { mutate: deletePages } = useMutation(
         deletePagesMutationOptions(queryClient),
+    );
+    const { mutate: deletePageYank } = useMutation(
+        deletePageYankMutationOptions(queryClient),
     );
 
     // Page clicking and dragging
@@ -253,6 +257,17 @@ export default function PageTimeline() {
         },
         [deletePages, setSelectedPage],
     );
+    const handleDeletePageYank = useCallback(
+        (page: Page) => {
+            deletePageYank(page.id, {
+                onSuccess: () => {
+                    if (page.previousPageId != null)
+                        setSelectedPage({ id: page.previousPageId });
+                },
+            });
+        },
+        [deletePageYank, setSelectedPage],
+    );
     return (
         <div className="flex h-fit gap-0" id="pages">
             {/* ------------------------------------ FIRST PAGE ------------------------------------ */}
@@ -435,20 +450,57 @@ export default function PageTimeline() {
                                             checked={page?.isSubset || false}
                                         />
                                     </div>
-                                    <div className="flex w-full items-center justify-between gap-8">
-                                        <label className="text-body text-text-subtitle">
-                                            <T keyName="timeline.page.contextMenu.deletePage" />
-                                        </label>
-                                        <Button
-                                            onClick={() =>
-                                                handleDeletePage(page)
-                                            }
-                                            size="compact"
-                                            variant="red"
-                                            content="icon"
-                                        >
-                                            <TrashIcon size={20} />
-                                        </Button>
+                                    <div className="border-stroke flex w-full flex-col items-start gap-8 border-t pt-8">
+                                        <div className="text-text flex items-center gap-6 text-xs">
+                                            <TrashIcon size={16} />
+                                            <T keyName="timeline.page.contextMenu.delete" />
+                                        </div>
+                                        <ToolTip.Root delayDuration={500}>
+                                            <ToolTip.Trigger asChild>
+                                                <button
+                                                    className="text-body text-text-subtitle hover:text-red cursor-pointer text-left transition-colors"
+                                                    onClick={() =>
+                                                        handleDeletePageYank(
+                                                            page,
+                                                        )
+                                                    }
+                                                >
+                                                    <T keyName="timeline.page.contextMenu.deleteYank" />
+                                                </button>
+                                            </ToolTip.Trigger>
+                                            <ToolTip.Portal>
+                                                <ToolTip.Content
+                                                    className={TooltipClassName}
+                                                    side="right"
+                                                >
+                                                    {t(
+                                                        "timeline.page.contextMenu.deleteYankTooltip",
+                                                    )}
+                                                </ToolTip.Content>
+                                            </ToolTip.Portal>
+                                        </ToolTip.Root>
+                                        <ToolTip.Root delayDuration={500}>
+                                            <ToolTip.Trigger asChild>
+                                                <button
+                                                    className="text-body text-text-subtitle hover:text-red cursor-pointer text-left transition-colors"
+                                                    onClick={() =>
+                                                        handleDeletePage(page)
+                                                    }
+                                                >
+                                                    <T keyName="timeline.page.contextMenu.deleteInPlace" />
+                                                </button>
+                                            </ToolTip.Trigger>
+                                            <ToolTip.Portal>
+                                                <ToolTip.Content
+                                                    className={TooltipClassName}
+                                                    side="right"
+                                                >
+                                                    {t(
+                                                        "timeline.page.contextMenu.deleteInPlaceTooltip",
+                                                    )}
+                                                </ToolTip.Content>
+                                            </ToolTip.Portal>
+                                        </ToolTip.Root>
                                     </div>
                                 </ContextMenu.Content>
                             </ContextMenu.Portal>

--- a/apps/desktop/src/db-functions/__test__/page.test.ts
+++ b/apps/desktop/src/db-functions/__test__/page.test.ts
@@ -3,6 +3,7 @@ import {
     createPages,
     updatePages,
     deletePages,
+    deletePageYank,
     FIRST_PAGE_ID,
     createLastPage,
     DatabasePage,
@@ -1733,6 +1734,101 @@ describeDbTests("pages", (it) => {
                                 (index + 1) * newPageCounts + 1,
                             );
                     }
+                },
+            );
+        });
+
+        describe("delete page yank", () => {
+            const createLastPages = async ({
+                db,
+                counts,
+            }: {
+                db: Parameters<typeof createLastPage>[0]["db"];
+                counts: number[];
+            }) => {
+                for (const newPageCounts of counts)
+                    await createLastPage({
+                        db,
+                        newPageCounts,
+                        createNewBeats: true,
+                    });
+                return await getPagesInOrder({ tx: db });
+            };
+
+            const pagePositions = (pages: DatabasePageWithBeat[]) =>
+                pages.map((page) => page.beatObject.position);
+
+            testWithHistory(
+                "pulls all subsequent pages back by the deleted page length",
+                async ({ db, expectNumberOfChanges }) => {
+                    const pagesBeforeDelete = await createLastPages({
+                        db,
+                        counts: [8, 12, 4, 10],
+                    });
+                    expect(pagePositions(pagesBeforeDelete)).toEqual([
+                        0, 1, 9, 21, 25,
+                    ]);
+
+                    const databaseState =
+                        await expectNumberOfChanges.getDatabaseState(db);
+
+                    const deletedPages = await deletePageYank({
+                        db,
+                        pageId: pagesBeforeDelete[2].id,
+                    });
+
+                    expect(deletedPages).toHaveLength(1);
+                    expect(deletedPages[0].id).toBe(pagesBeforeDelete[2].id);
+                    expect(
+                        pagePositions(await getPagesInOrder({ tx: db })),
+                    ).toEqual([0, 1, 9, 13]);
+
+                    await expectNumberOfChanges.test(db, 1, databaseState);
+                },
+            );
+
+            testWithHistory(
+                "pulls the third page to the second beat when yanking the second page",
+                async ({ db }) => {
+                    const pagesBeforeDelete = await createLastPages({
+                        db,
+                        counts: [16, 16, 16],
+                    });
+                    expect(pagePositions(pagesBeforeDelete)).toEqual([
+                        0, 1, 17, 33,
+                    ]);
+
+                    await deletePageYank({
+                        db,
+                        pageId: pagesBeforeDelete[1].id,
+                    });
+
+                    expect(
+                        pagePositions(await getPagesInOrder({ tx: db })),
+                    ).toEqual([0, 1, 17]);
+                },
+            );
+
+            testWithHistory(
+                "deleting the last page updates last page counts",
+                async ({ db }) => {
+                    const getLastPageCounts = async () =>
+                        (await db.query.utility.findFirst())!.last_page_counts;
+                    const pagesBeforeDelete = await createLastPages({
+                        db,
+                        counts: [9, 10, 23],
+                    });
+                    expect(await getLastPageCounts()).toBe(23);
+
+                    await deletePageYank({
+                        db,
+                        pageId: pagesBeforeDelete[3].id,
+                    });
+
+                    expect(await getLastPageCounts()).toBe(10);
+                    expect(
+                        pagePositions(await getPagesInOrder({ tx: db })),
+                    ).toEqual([0, 1, 10]);
                 },
             );
         });

--- a/apps/desktop/src/db-functions/page.ts
+++ b/apps/desktop/src/db-functions/page.ts
@@ -626,6 +626,71 @@ export async function deletePages({
     return response;
 }
 
+export async function deletePageYank({
+    pageId,
+    db,
+}: {
+    pageId: number;
+    db: DbConnection;
+}): Promise<DatabasePage[]> {
+    if (pageId === FIRST_PAGE_ID) return [];
+
+    const response = await transactionWithHistory(
+        db,
+        "deletePageYank",
+        async (tx) => {
+            const pagesBeforeDeletion = await tx
+                .select()
+                .from(schema.pages)
+                .innerJoin(
+                    schema.beats,
+                    eq(schema.beats.id, schema.pages.start_beat),
+                )
+                .orderBy(asc(schema.beats.position))
+                .all();
+            const pageToDeleteIndex = pagesBeforeDeletion.findIndex(
+                ({ pages }) => pages.id === pageId,
+            );
+            if (pageToDeleteIndex === -1) return [];
+
+            const pageToDelete = pagesBeforeDeletion[pageToDeleteIndex];
+            const nextPage = pagesBeforeDeletion[pageToDeleteIndex + 1];
+            const yankLength = nextPage
+                ? nextPage.beats.position - pageToDelete.beats.position
+                : 0;
+            const laterPages = pagesBeforeDeletion.slice(pageToDeleteIndex + 1);
+
+            const response = await deletePagesInTransaction({
+                pageIds: new Set([pageId]),
+                tx,
+            });
+
+            if (yankLength > 0) {
+                for (const page of laterPages) {
+                    const targetBeat = await tx.query.beats.findFirst({
+                        where: eq(
+                            schema.beats.position,
+                            page.beats.position - yankLength,
+                        ),
+                    });
+                    assert(
+                        targetBeat != null,
+                        `Could not find target beat for yanked page ${page.pages.id}`,
+                    );
+                    await tx
+                        .update(schema.pages)
+                        .set({ start_beat: targetBeat.id })
+                        .where(eq(schema.pages.id, page.pages.id));
+                }
+            }
+
+            await ensureSecondBeatHasPage({ tx });
+            return response;
+        },
+    );
+    return response;
+}
+
 /**
  * Creates a new page at the next available beat after the current last page.
  *

--- a/apps/desktop/src/db-functions/page.ts
+++ b/apps/desktop/src/db-functions/page.ts
@@ -635,31 +635,23 @@ export async function deletePageYank({
 }): Promise<DatabasePage[]> {
     if (pageId === FIRST_PAGE_ID) return [];
 
+    const pagesBeforeDeletion = await getPagesInOrder({ tx: db });
+    const pageToDeleteIndex = pagesBeforeDeletion.findIndex(
+        (p) => p.id === pageId,
+    );
+    assert(pageToDeleteIndex !== -1, `Page ${pageId} not found`);
+
+    const pageToDelete = pagesBeforeDeletion[pageToDeleteIndex];
+    const nextPage = pagesBeforeDeletion[pageToDeleteIndex + 1];
+    const yankLength = nextPage
+        ? nextPage.beatObject.position - pageToDelete.beatObject.position
+        : 0;
+    const laterPages = pagesBeforeDeletion.slice(pageToDeleteIndex + 1);
+
     const response = await transactionWithHistory(
         db,
         "deletePageYank",
         async (tx) => {
-            const pagesBeforeDeletion = await tx
-                .select()
-                .from(schema.pages)
-                .innerJoin(
-                    schema.beats,
-                    eq(schema.beats.id, schema.pages.start_beat),
-                )
-                .orderBy(asc(schema.beats.position))
-                .all();
-            const pageToDeleteIndex = pagesBeforeDeletion.findIndex(
-                ({ pages }) => pages.id === pageId,
-            );
-            if (pageToDeleteIndex === -1) return [];
-
-            const pageToDelete = pagesBeforeDeletion[pageToDeleteIndex];
-            const nextPage = pagesBeforeDeletion[pageToDeleteIndex + 1];
-            const yankLength = nextPage
-                ? nextPage.beats.position - pageToDelete.beats.position
-                : 0;
-            const laterPages = pagesBeforeDeletion.slice(pageToDeleteIndex + 1);
-
             const response = await deletePagesInTransaction({
                 pageIds: new Set([pageId]),
                 tx,
@@ -670,17 +662,17 @@ export async function deletePageYank({
                     const targetBeat = await tx.query.beats.findFirst({
                         where: eq(
                             schema.beats.position,
-                            page.beats.position - yankLength,
+                            page.beatObject.position - yankLength,
                         ),
                     });
                     assert(
                         targetBeat != null,
-                        `Could not find target beat for yanked page ${page.pages.id}`,
+                        `Could not find target beat for yanked page ${page.id}`,
                     );
                     await tx
                         .update(schema.pages)
                         .set({ start_beat: targetBeat.id })
-                        .where(eq(schema.pages.id, page.pages.id));
+                        .where(eq(schema.pages.id, page.id));
                 }
             }
 

--- a/apps/desktop/src/hooks/queries/usePages.ts
+++ b/apps/desktop/src/hooks/queries/usePages.ts
@@ -13,6 +13,7 @@ import {
     getPages,
     realDatabasePageToDatabasePage,
     deletePages,
+    deletePageYank,
     transactionWithHistory,
     updatePagesInTransaction,
     updateLastPageCounts,
@@ -211,6 +212,23 @@ export const deletePagesMutationOptions = (qc: QueryClient) => {
         onSuccess: async (_, variables) => {
             toast.success(tolgee.t("pages.deletedSuccessfully"));
             // Invalidate all page queries
+            void invalidatePageQueries(qc);
+        },
+        onError: (e, variables) => {
+            conToastError(
+                tolgee.t("pages.deleteFailed", { error: e.message }),
+                e,
+                variables,
+            );
+        },
+    });
+};
+
+export const deletePageYankMutationOptions = (qc: QueryClient) => {
+    return mutationOptions({
+        mutationFn: (pageId: number) => deletePageYank({ db, pageId }),
+        onSuccess: async (_, variables) => {
+            toast.success(tolgee.t("pages.deletedSuccessfully"));
             void invalidatePageQueries(qc);
         },
         onError: (e, variables) => {

--- a/apps/desktop/src/hooks/queries/usePages.ts
+++ b/apps/desktop/src/hooks/queries/usePages.ts
@@ -229,7 +229,7 @@ export const deletePageYankMutationOptions = (qc: QueryClient) => {
         mutationFn: (pageId: number) => deletePageYank({ db, pageId }),
         onSuccess: async (_, variables) => {
             toast.success(tolgee.t("pages.deletedSuccessfully"));
-            void invalidatePageQueries(qc);
+            await invalidatePageQueries(qc);
         },
         onError: (e, variables) => {
             conToastError(


### PR DESCRIPTION
Add option in page deleting that yanks/pulls subsequent pages, in addition to leaving them in place
<img width="137" height="188" alt="image" src="https://github.com/user-attachments/assets/57500775-af7c-464e-aec6-9d896bedd0a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate page deletion actions in the timeline page context menu: **Delete**, **Delete in place**, and **Delete yank** (with tooltips).
* **Bug Fixes**
  * Improved how subsequent pages are re-aligned after deleting, keeping page beat positions consistent.
* **Documentation**
  * Updated localized menu labels and tooltip text across supported languages to match the new deletion actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->