### PR TITLE
Fix split page deadlock

### DIFF
--- a/apps/desktop/src/components/inspector/PageEditorUtils.ts
+++ b/apps/desktop/src/components/inspector/PageEditorUtils.ts
@@ -1,7 +1,8 @@
 import {
     transactionWithHistory,
-    createPages,
+    createPagesInTransaction,
     updatePagesInTransaction,
+    updateLastPageCounts,
 } from "@/db-functions";
 import { db } from "@/global/database/db";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -29,17 +30,27 @@ export const _splitPage = async ({ page }: SplitPageArgs) => {
 
     await transactionWithHistory(db, "splitPage", async (tx) => {
         // Create the new page
-        await createPages({
+        await createPagesInTransaction({
             newPages: [splitResult.newPageArgs],
-            db: tx,
+            tx,
         });
 
         // Update the original page if needed
         if (splitResult.modifyPageRequest) {
-            await updatePagesInTransaction({
-                modifiedPages: splitResult.modifyPageRequest.modifiedPagesArgs,
-                tx,
-            });
+            if (splitResult.modifyPageRequest.modifiedPagesArgs.length > 0) {
+                await updatePagesInTransaction({
+                    modifiedPages:
+                        splitResult.modifyPageRequest.modifiedPagesArgs,
+                    tx,
+                });
+            }
+            if (splitResult.modifyPageRequest.lastPageCounts != null) {
+                await updateLastPageCounts({
+                    lastPageCounts:
+                        splitResult.modifyPageRequest.lastPageCounts,
+                    tx,
+                });
+            }
         }
     });
 };


### PR DESCRIPTION
## Summary
- Avoid nesting `transactionWithHistory` when splitting pages by using `createPagesInTransaction` inside the existing split transaction
- Update final-page count metadata inside the same transaction when splitting the last page

## Why
Splitting a page could hang after logging `start splitPage` because the split operation opened a history transaction and then called `createPages`, which attempted to open a second history transaction. The history transaction lock serialized these calls, causing the outer transaction to await an inner transaction that could not start.

## Testing
- `pnpm tsc --noEmit` from `apps/desktop`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page splitting so changes are saved more reliably.
  * Updated split-related edits to only apply when needed, reducing unexpected updates.
  * Ensured page count information stays in sync after splitting pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->