### PR TITLE
Import previous dots file

### DIFF
--- a/apps/desktop/e2e/tests/new-show-wizard.spec.mts
+++ b/apps/desktop/e2e/tests/new-show-wizard.spec.mts
@@ -5,6 +5,7 @@ import path from "path";
 import {
     completeNewShowWizard,
     fillProjectStep,
+    goToProjectStep,
     openNewShowWizard,
 } from "../utils/new-show-wizard.mjs";
 
@@ -19,6 +20,7 @@ test("Project validation requires show name", async ({ electronAppEmpty }) => {
     const dialog = page.getByRole("dialog", { name: "New show" });
 
     await openNewShowWizard(page);
+    await goToProjectStep(page);
     await expect(dialog.getByRole("button", { name: "Next" })).toBeDisabled();
 
     await fillProjectStep(page, "Test Show");
@@ -60,6 +62,7 @@ test("Back navigation returns to project step", async ({
     const dialog = page.getByRole("dialog", { name: "New show" });
 
     await openNewShowWizard(page);
+    await goToProjectStep(page);
     await fillProjectStep(page, "Back Nav Test");
     await dialog.getByRole("button", { name: "Next" }).click();
 
@@ -88,6 +91,7 @@ test("Exit confirm on discard", async ({ electronAppEmpty }) => {
     const { page } = electronAppEmpty;
 
     await openNewShowWizard(page);
+    await goToProjectStep(page);
     await fillProjectStep(page, "Discard Test");
     await page.keyboard.press("Escape");
 
@@ -103,6 +107,7 @@ test("Refresh during wizard discards draft and returns to launch page", async ({
     const dialog = page.getByRole("dialog", { name: "New show" });
 
     await openNewShowWizard(page);
+    await goToProjectStep(page);
     await fillProjectStep(page, "Refresh Test");
     await dialog.getByRole("button", { name: "Next" }).click();
 

--- a/apps/desktop/e2e/tests/new-show-wizard.spec.mts
+++ b/apps/desktop/e2e/tests/new-show-wizard.spec.mts
@@ -21,7 +21,9 @@ test("Project validation requires show name", async ({ electronAppEmpty }) => {
 
     await openNewShowWizard(page);
     await goToProjectStep(page);
-    await expect(dialog.getByRole("button", { name: "Next" })).toBeDisabled();
+    await expect(
+        dialog.getByRole("button", { name: "Next", exact: true }),
+    ).toBeDisabled();
 
     await fillProjectStep(page, "Test Show");
 });
@@ -64,7 +66,7 @@ test("Back navigation returns to project step", async ({
     await openNewShowWizard(page);
     await goToProjectStep(page);
     await fillProjectStep(page, "Back Nav Test");
-    await dialog.getByRole("button", { name: "Next" }).click();
+    await dialog.getByRole("button", { name: "Next", exact: true }).click();
 
     await expect(
         dialog.getByRole("heading", {
@@ -109,7 +111,7 @@ test("Refresh during wizard discards draft and returns to launch page", async ({
     await openNewShowWizard(page);
     await goToProjectStep(page);
     await fillProjectStep(page, "Refresh Test");
-    await dialog.getByRole("button", { name: "Next" }).click();
+    await dialog.getByRole("button", { name: "Next", exact: true }).click();
 
     await expect(
         dialog.getByRole("heading", {

--- a/apps/desktop/e2e/utils/new-show-wizard.mts
+++ b/apps/desktop/e2e/utils/new-show-wizard.mts
@@ -13,6 +13,25 @@ export async function openNewShowWizard(page: Page) {
     await expect(dialog).toBeVisible();
     await expect(
         dialog.getByRole("heading", {
+            name: "Start setup",
+            exact: true,
+            level: 2,
+        }),
+    ).toBeVisible();
+}
+
+export async function selectBlankStart(page: Page) {
+    const dialog = wizardDialog(page);
+    await dialog.getByRole("button", { name: /Start blank show/ }).click();
+    await expect(dialog.getByRole("button", { name: "Next" })).toBeEnabled();
+}
+
+export async function goToProjectStep(page: Page) {
+    await selectBlankStart(page);
+    const dialog = wizardDialog(page);
+    await dialog.getByRole("button", { name: "Next" }).click();
+    await expect(
+        dialog.getByRole("heading", {
             name: "Project details",
             exact: true,
             level: 2,
@@ -33,6 +52,7 @@ export async function completeNewShowWizard(
     { projectName }: CompleteNewShowWizardOptions,
 ) {
     await openNewShowWizard(page);
+    await goToProjectStep(page);
     await fillProjectStep(page, projectName);
 
     const dialog = wizardDialog(page);

--- a/apps/desktop/e2e/utils/new-show-wizard.mts
+++ b/apps/desktop/e2e/utils/new-show-wizard.mts
@@ -23,13 +23,15 @@ export async function openNewShowWizard(page: Page) {
 export async function selectBlankStart(page: Page) {
     const dialog = wizardDialog(page);
     await dialog.getByRole("button", { name: /Start blank show/ }).click();
-    await expect(dialog.getByRole("button", { name: "Next" })).toBeEnabled();
+    await expect(
+        dialog.getByRole("button", { name: "Next", exact: true }),
+    ).toBeEnabled();
 }
 
 export async function goToProjectStep(page: Page) {
     await selectBlankStart(page);
     const dialog = wizardDialog(page);
-    await dialog.getByRole("button", { name: "Next" }).click();
+    await dialog.getByRole("button", { name: "Next", exact: true }).click();
     await expect(
         dialog.getByRole("heading", {
             name: "Project details",
@@ -42,7 +44,9 @@ export async function goToProjectStep(page: Page) {
 export async function fillProjectStep(page: Page, projectName: string) {
     const dialog = wizardDialog(page);
     await dialog.getByRole("textbox", { name: "Show name" }).fill(projectName);
-    await expect(dialog.getByRole("button", { name: "Next" })).toBeEnabled({
+    await expect(
+        dialog.getByRole("button", { name: "Next", exact: true }),
+    ).toBeEnabled({
         timeout: 5000,
     });
 }
@@ -57,7 +61,7 @@ export async function completeNewShowWizard(
 
     const dialog = wizardDialog(page);
 
-    await dialog.getByRole("button", { name: "Next" }).click();
+    await dialog.getByRole("button", { name: "Next", exact: true }).click();
     await expect(
         dialog.getByRole("heading", {
             name: "Activity",
@@ -65,7 +69,7 @@ export async function completeNewShowWizard(
             level: 2,
         }),
     ).toBeVisible();
-    await dialog.getByRole("button", { name: "Next" }).click();
+    await dialog.getByRole("button", { name: "Next", exact: true }).click();
 
     await expect(
         dialog.getByRole("heading", {
@@ -74,7 +78,7 @@ export async function completeNewShowWizard(
             level: 2,
         }),
     ).toBeVisible();
-    await dialog.getByRole("button", { name: "Next" }).click();
+    await dialog.getByRole("button", { name: "Next", exact: true }).click();
 
     await expect(
         dialog.getByRole("heading", {

--- a/apps/desktop/electron/database/database.services.ts
+++ b/apps/desktop/electron/database/database.services.ts
@@ -3,9 +3,8 @@ import { ipcMain } from "electron";
 import type { DatabaseSync } from "node:sqlite";
 import Constants from "../../src/global/Constants";
 import * as fs from "fs";
-import AudioFile, {
-    ModifiedAudioFileArgs,
-} from "../../src/global/classes/AudioFile";
+import type AudioFile from "../../src/global/classes/AudioFile";
+import type { ModifiedAudioFileArgs } from "../../src/global/classes/AudioFile";
 import { getOrm } from "./db";
 
 export class LegacyDatabaseResponse<T> {

--- a/apps/desktop/electron/database/migrations/schema.ts
+++ b/apps/desktop/electron/database/migrations/schema.ts
@@ -395,6 +395,11 @@ export const workspace_settings = sqliteTable(
 );
 
 /* =========================== VIEWS =========================== */
+/**
+ * An ordered list of the beats, pages, and measures in the app.
+ *
+ * This view should be used when needing to sort by page order.
+ */
 export const timing_objects = sqliteView("timing_objects", {
     position: integer("position").notNull(),
     duration: real("duration").notNull(),

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -32,6 +32,7 @@ import { DrizzleMigrationService } from "../database/services/DrizzleMigrationSe
 import { getOrm } from "../database/db";
 import { getAutoUpdater } from "./update";
 import { repairDatabase } from "../database/repair";
+import { choosePreviousDotsFile } from "./services/previous-dots-import-service";
 import {
     initAuthBeforeReady,
     initAuthAfterReady,
@@ -363,6 +364,9 @@ function initDatabaseIpcHandlers() {
     );
     ipcMain.handle("newShow:discardDraft", async () => discardNewShowDraft());
     ipcMain.handle("newShow:getDraftPath", () => currentNewShowDraftPath);
+    ipcMain.handle("newShow:choosePreviousDotsFile", async () =>
+        choosePreviousDotsFile(win),
+    );
     ipcMain.handle("database:repair", async (_, dbPath: string) => {
         try {
             DatabaseServices.closePersistentConnection();

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -25,7 +25,7 @@ import {
     updateRecentFileSvgPreview,
     clearMissingRecentFiles,
 } from "./services/recent-files-service";
-import AudioFile from "../../src/global/classes/AudioFile";
+import type AudioFile from "../../src/global/classes/AudioFile";
 import { init, captureException } from "@sentry/electron/main";
 
 import { DrizzleMigrationService } from "../database/services/DrizzleMigrationService";

--- a/apps/desktop/electron/main/services/export-service.ts
+++ b/apps/desktop/electron/main/services/export-service.ts
@@ -7,7 +7,7 @@ import sanitize from "sanitize-filename";
 import PDFDocument from "pdfkit";
 // @ts-ignore - svg-to-pdfkit doesn't have types
 import SVGtoPDF from "svg-to-pdfkit";
-import Page from "../../../src/global/classes/Page";
+import type Page from "../../../src/global/classes/Page";
 import sanitizeHtml from "sanitize-html";
 
 import Store from "electron-store";

--- a/apps/desktop/electron/main/services/export-utility-process.ts
+++ b/apps/desktop/electron/main/services/export-utility-process.ts
@@ -3,9 +3,9 @@ import { DatabaseSync } from "node:sqlite";
 import PDFDocument from "pdfkit";
 import fs from "fs";
 import { ReadableCoords } from "@/global/classes/ReadableCoords";
-import Marcher from "@/global/classes/Marcher";
-import Page from "@/global/classes/Page";
-import MarcherPage from "@/global/classes/MarcherPage";
+import type Marcher from "@/global/classes/Marcher";
+import type Page from "@/global/classes/Page";
+import type MarcherPage from "@/global/classes/MarcherPage";
 import { FieldProperties } from "@openmarch/core";
 import { getOrm } from "@om-electron/database/db";
 

--- a/apps/desktop/electron/main/services/previous-dots-import-service.ts
+++ b/apps/desktop/electron/main/services/previous-dots-import-service.ts
@@ -3,6 +3,7 @@ import { dialog } from "electron";
 import type { BrowserWindow } from "electron";
 import { DatabaseSync } from "node:sqlite";
 import { desc, eq, isNotNull } from "drizzle-orm";
+import { parseFromWorkspaceSettings } from "@/components/launchpage/parseFromWorkspaceSettings";
 
 export interface PreviousDotsMarcherImport {
     name?: string | null;
@@ -54,6 +55,9 @@ export interface PreviousDotsImportResult {
     sectionAppearances: PreviousDotsSectionAppearanceImport[];
     tags: PreviousDotsTagImport[];
     marcherTags: PreviousDotsMarcherTagImport[];
+    designer?: string;
+    client?: string;
+    activity?: string;
 }
 
 // eslint-disable-next-line max-lines-per-function
@@ -136,6 +140,21 @@ async function readPreviousDotsFile(
             )
             .all();
 
+        let workspaceSettingsJson: string | undefined;
+        try {
+            const workspaceSettings =
+                await orm.query.workspace_settings.findFirst({
+                    columns: { json_data: true },
+                });
+            workspaceSettingsJson = workspaceSettings?.json_data;
+        } catch {
+            // Older files may lack workspace_settings
+        }
+
+        const { designer, client, activity } = parseFromWorkspaceSettings(
+            workspaceSettingsJson,
+        );
+
         const fieldImage = fieldProperties.image
             ? new Uint8Array(fieldProperties.image)
             : null;
@@ -155,6 +174,9 @@ async function readPreviousDotsFile(
                 color_hex: tag.color_hex,
             })),
             marcherTags: marcherTagsRaw,
+            designer,
+            client,
+            activity,
         };
     } finally {
         db.close();

--- a/apps/desktop/electron/main/services/previous-dots-import-service.ts
+++ b/apps/desktop/electron/main/services/previous-dots-import-service.ts
@@ -1,0 +1,105 @@
+import { getOrm, schema } from "@om-electron/database/db";
+import { dialog } from "electron";
+import type { BrowserWindow } from "electron";
+import { DatabaseSync } from "node:sqlite";
+import { desc, eq } from "drizzle-orm";
+
+export interface PreviousDotsMarcherImport {
+    name?: string | null;
+    section: string;
+    drill_prefix: string;
+    drill_order: number;
+    year?: string | null;
+    notes?: string | null;
+}
+
+export interface PreviousDotsCoordinateImport {
+    drill_prefix: string;
+    drill_order: number;
+    x: number;
+    y: number;
+}
+
+export interface PreviousDotsImportResult {
+    sourcePath: string;
+    fieldPropertiesJson: string;
+    marchers: PreviousDotsMarcherImport[];
+    coordinates: PreviousDotsCoordinateImport[];
+}
+
+async function readPreviousDotsFile(
+    sourcePath: string,
+): Promise<PreviousDotsImportResult> {
+    const db = new DatabaseSync(sourcePath, { readOnly: true });
+    try {
+        const orm = getOrm(db);
+        const fieldProperties = await orm.query.field_properties.findFirst({
+            columns: { json_data: true },
+        });
+
+        if (!fieldProperties?.json_data)
+            throw new Error("Field properties not found in source file");
+
+        const marchers = await orm
+            .select()
+            .from(schema.marchers)
+            .orderBy(
+                schema.marchers.drill_prefix,
+                schema.marchers.drill_order,
+                schema.marchers.year,
+                schema.marchers.notes,
+            )
+            .all();
+
+        const lastPage = await orm
+            .select({ page_id: schema.timing_objects.page_id })
+            .from(schema.timing_objects)
+            .orderBy(desc(schema.timing_objects.position))
+            .limit(1)
+            .get();
+
+        if (!lastPage?.page_id)
+            throw new Error("No timing objects found in source file");
+
+        const coordinates = await orm
+            .select({
+                drill_prefix: schema.marchers.drill_prefix,
+                drill_order: schema.marchers.drill_order,
+                x: schema.marcher_pages.x,
+                y: schema.marcher_pages.y,
+            })
+            .from(schema.marcher_pages)
+            .innerJoin(
+                schema.marchers,
+                eq(schema.marcher_pages.marcher_id, schema.marchers.id),
+            )
+            .where(eq(schema.marcher_pages.page_id, lastPage.page_id))
+            .all();
+
+        return {
+            sourcePath,
+            fieldPropertiesJson: fieldProperties.json_data,
+            marchers: marchers.map(({ id: _id, ...marcher }) => marcher),
+            coordinates,
+        };
+    } finally {
+        db.close();
+    }
+}
+
+export async function choosePreviousDotsFile(
+    win: BrowserWindow | null,
+): Promise<PreviousDotsImportResult | null> {
+    if (!win) return null;
+
+    const result = await dialog.showOpenDialog(win, {
+        filters: [
+            { name: "OpenMarch File", extensions: ["dots"] },
+            { name: "All Files", extensions: ["*"] },
+        ],
+        properties: ["openFile"],
+    });
+
+    if (result.canceled || !result.filePaths[0]) return null;
+    return await readPreviousDotsFile(result.filePaths[0]);
+}

--- a/apps/desktop/electron/main/services/previous-dots-import-service.ts
+++ b/apps/desktop/electron/main/services/previous-dots-import-service.ts
@@ -2,8 +2,9 @@ import { getOrm, schema } from "@om-electron/database/db";
 import { dialog } from "electron";
 import type { BrowserWindow } from "electron";
 import { DatabaseSync } from "node:sqlite";
-import { desc, eq, isNotNull } from "drizzle-orm";
+import { asc, desc, eq, isNotNull } from "drizzle-orm";
 import { parseFromWorkspaceSettings } from "@/components/launchpage/parseFromWorkspaceSettings";
+import { getLastPageNumber } from "@/global/classes/Page";
 
 export interface PreviousDotsMarcherImport {
     name?: string | null;
@@ -58,6 +59,8 @@ export interface PreviousDotsImportResult {
     designer?: string;
     client?: string;
     activity?: string;
+    /** Last named page number from the source file; used as the new show's pageNumberOffset. */
+    pageNumberOffset: number;
 }
 
 // eslint-disable-next-line max-lines-per-function
@@ -151,8 +154,27 @@ async function readPreviousDotsFile(
             // Older files may lack workspace_settings
         }
 
-        const { designer, client, activity } = parseFromWorkspaceSettings(
-            workspaceSettingsJson,
+        const {
+            designer,
+            client,
+            activity,
+            pageNumberOffset: sourcePageNumberOffset,
+        } = parseFromWorkspaceSettings(workspaceSettingsJson);
+
+        const orderedPages = await orm
+            .select({ is_subset: schema.pages.is_subset })
+            .from(schema.pages)
+            .innerJoin(
+                schema.beats,
+                eq(schema.pages.start_beat, schema.beats.id),
+            )
+            .orderBy(asc(schema.beats.position))
+            .all();
+
+        const isSubsetFlags = orderedPages.map((page) => page.is_subset === 1);
+        const pageNumberOffset = getLastPageNumber(
+            isSubsetFlags,
+            sourcePageNumberOffset ?? 0,
         );
 
         const fieldImage = fieldProperties.image
@@ -177,6 +199,7 @@ async function readPreviousDotsFile(
             designer,
             client,
             activity,
+            pageNumberOffset,
         };
     } finally {
         db.close();

--- a/apps/desktop/electron/main/services/previous-dots-import-service.ts
+++ b/apps/desktop/electron/main/services/previous-dots-import-service.ts
@@ -4,7 +4,7 @@ import type { BrowserWindow } from "electron";
 import { DatabaseSync } from "node:sqlite";
 import { asc, desc, eq, isNotNull } from "drizzle-orm";
 import { parseFromWorkspaceSettings } from "@/components/launchpage/parseFromWorkspaceSettings";
-import { getLastPageNumber } from "@/global/classes/Page";
+import { getLastPageNumber } from "@openmarch/core";
 
 export interface PreviousDotsMarcherImport {
     name?: string | null;

--- a/apps/desktop/electron/main/services/previous-dots-import-service.ts
+++ b/apps/desktop/electron/main/services/previous-dots-import-service.ts
@@ -2,7 +2,7 @@ import { getOrm, schema } from "@om-electron/database/db";
 import { dialog } from "electron";
 import type { BrowserWindow } from "electron";
 import { DatabaseSync } from "node:sqlite";
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, isNotNull } from "drizzle-orm";
 
 export interface PreviousDotsMarcherImport {
     name?: string | null;
@@ -20,13 +20,43 @@ export interface PreviousDotsCoordinateImport {
     y: number;
 }
 
+export interface PreviousDotsSectionAppearanceImport {
+    section: string;
+    fill_color: string | null;
+    outline_color: string | null;
+    shape_type: string | null;
+    visible: number;
+    label_visible: number;
+    equipment_name: string | null;
+    equipment_state: string | null;
+}
+
+export interface PreviousDotsTagImport {
+    key: number;
+    name?: string | null;
+    description?: string | null;
+    icon?: string | null;
+    color_hex?: string | null;
+}
+
+export interface PreviousDotsMarcherTagImport {
+    drill_prefix: string;
+    drill_order: number;
+    tagKey: number;
+}
+
 export interface PreviousDotsImportResult {
     sourcePath: string;
     fieldPropertiesJson: string;
+    fieldImage: Uint8Array | null;
     marchers: PreviousDotsMarcherImport[];
     coordinates: PreviousDotsCoordinateImport[];
+    sectionAppearances: PreviousDotsSectionAppearanceImport[];
+    tags: PreviousDotsTagImport[];
+    marcherTags: PreviousDotsMarcherTagImport[];
 }
 
+// eslint-disable-next-line max-lines-per-function
 async function readPreviousDotsFile(
     sourcePath: string,
 ): Promise<PreviousDotsImportResult> {
@@ -34,7 +64,7 @@ async function readPreviousDotsFile(
     try {
         const orm = getOrm(db);
         const fieldProperties = await orm.query.field_properties.findFirst({
-            columns: { json_data: true },
+            columns: { json_data: true, image: true },
         });
 
         if (!fieldProperties?.json_data)
@@ -54,6 +84,7 @@ async function readPreviousDotsFile(
         const lastPage = await orm
             .select({ page_id: schema.timing_objects.page_id })
             .from(schema.timing_objects)
+            .where(isNotNull(schema.timing_objects.page_id))
             .orderBy(desc(schema.timing_objects.position))
             .limit(1)
             .get();
@@ -76,11 +107,54 @@ async function readPreviousDotsFile(
             .where(eq(schema.marcher_pages.page_id, lastPage.page_id))
             .all();
 
+        const sectionAppearancesRaw = await orm
+            .select({
+                section: schema.section_appearances.section,
+                fill_color: schema.section_appearances.fill_color,
+                outline_color: schema.section_appearances.outline_color,
+                shape_type: schema.section_appearances.shape_type,
+                visible: schema.section_appearances.visible,
+                label_visible: schema.section_appearances.label_visible,
+                equipment_name: schema.section_appearances.equipment_name,
+                equipment_state: schema.section_appearances.equipment_state,
+            })
+            .from(schema.section_appearances)
+            .all();
+
+        const tagsRaw = await orm.select().from(schema.tags).all();
+
+        const marcherTagsRaw = await orm
+            .select({
+                drill_prefix: schema.marchers.drill_prefix,
+                drill_order: schema.marchers.drill_order,
+                tagKey: schema.marcher_tags.tag_id,
+            })
+            .from(schema.marcher_tags)
+            .innerJoin(
+                schema.marchers,
+                eq(schema.marcher_tags.marcher_id, schema.marchers.id),
+            )
+            .all();
+
+        const fieldImage = fieldProperties.image
+            ? new Uint8Array(fieldProperties.image)
+            : null;
+
         return {
             sourcePath,
             fieldPropertiesJson: fieldProperties.json_data,
+            fieldImage,
             marchers: marchers.map(({ id: _id, ...marcher }) => marcher),
             coordinates,
+            sectionAppearances: sectionAppearancesRaw,
+            tags: tagsRaw.map((tag) => ({
+                key: tag.id,
+                name: tag.name,
+                description: tag.description,
+                icon: tag.icon,
+                color_hex: tag.color_hex,
+            })),
+            marcherTags: marcherTagsRaw,
         };
     } finally {
         db.close();

--- a/apps/desktop/electron/preload/index.ts
+++ b/apps/desktop/electron/preload/index.ts
@@ -10,6 +10,7 @@ import * as DbServices from "@om-electron/database/database.services";
 
 import Plugin from "../../src/global/classes/Plugin";
 import type { RecentFile } from "@om-electron/main/services/recent-files-service";
+import type { PreviousDotsImportResult } from "@om-electron/main/services/previous-dots-import-service";
 import type {
     AuthState,
     AuthError,
@@ -228,6 +229,10 @@ const APP_API = {
         ipcRenderer.invoke("newShow:discardDraft") as Promise<number>,
     getNewShowDraftPath: () =>
         ipcRenderer.invoke("newShow:getDraftPath") as Promise<string | null>,
+    choosePreviousDotsFile: () =>
+        ipcRenderer.invoke(
+            "newShow:choosePreviousDotsFile",
+        ) as Promise<PreviousDotsImportResult | null>,
 
     export: {
         pdf: (params: {

--- a/apps/desktop/electron/preload/index.ts
+++ b/apps/desktop/electron/preload/index.ts
@@ -1,5 +1,6 @@
-import AudioFile, { ModifiedAudioFileArgs } from "@/global/classes/AudioFile";
-import Page from "@/global/classes/Page";
+import type AudioFile from "@/global/classes/AudioFile";
+import type { ModifiedAudioFileArgs } from "@/global/classes/AudioFile";
+import type Page from "@/global/classes/Page";
 import {
     contextBridge,
     ipcRenderer,
@@ -19,7 +20,7 @@ import type {
     AccessTokenResult,
 } from "@om-electron/main/auth/types";
 import { AUTH_IPC_CHANNELS } from "../../src/global/auth/constants";
-import { HistoryResponse } from "@/db-functions";
+import type { HistoryResponse } from "@/db-functions";
 
 function domReady(
     condition: DocumentReadyState[] = ["complete", "interactive"],

--- a/apps/desktop/i18n/en.json
+++ b/apps/desktop/i18n/en.json
@@ -661,6 +661,15 @@
                 "confirm": "Discard"
             },
             "steps": {
+                "start": {
+                    "title": "Start setup",
+                    "description": "Choose how to start this show.",
+                    "blank": "Start blank show",
+                    "blankDescription": "Choose field and performers in the next steps.",
+                    "importPrevious": "Import previous .dots file",
+                    "importPreviousDescription": "Reuse performers, field setup, and the last set coordinates from an existing show.",
+                    "importSummary": "Selected {fileName}. {count, plural, one {# performer} other {# performers}} will be imported."
+                },
                 "project": {
                     "title": "Project details",
                     "description": "Name your show and choose where to save it."
@@ -706,6 +715,7 @@
             "errors": {
                 "nameRequired": "Show name is required",
                 "createFailed": "Failed to create show",
+                "importFailed": "Failed to import previous .dots file",
                 "audioNotSaved": "Audio may not have been saved. You can add audio later in the editor.",
                 "xmlNotImported": "MusicXML may not have been imported. You can import it later in the editor."
             }

--- a/apps/desktop/i18n/en.json
+++ b/apps/desktop/i18n/en.json
@@ -668,6 +668,7 @@
             "errors": {
                 "audioNotSaved": "Audio may not have been saved. You can add audio later in the editor.",
                 "createFailed": "Failed to create show",
+                "importFailed": "Failed to import previous .dots file",
                 "nameRequired": "Show name is required",
                 "xmlNotImported": "MusicXML may not have been imported. You can import it later in the editor."
             },
@@ -710,6 +711,15 @@
                 "project": {
                     "description": "Name your show and choose where to save it.",
                     "title": "Project details"
+                },
+                "start": {
+                    "blank": "Start blank show",
+                    "blankDescription": "Choose field and performers in the next steps.",
+                    "description": "Choose how to start this show.",
+                    "importPrevious": "Import previous .dots file",
+                    "importPreviousDescription": "Reuse performers, field setup, and the last set coordinates from an existing show.",
+                    "importSummary": "Selected {fileName}. {count, plural, one {# performer} other {# performers}} will be imported.",
+                    "title": "Start setup"
                 },
                 "tempo": {
                     "dbNotReady": "The show file is not ready. Go back to the project step and try again.",

--- a/apps/desktop/src/components/launchpage/NewShowDialog.tsx
+++ b/apps/desktop/src/components/launchpage/NewShowDialog.tsx
@@ -301,6 +301,15 @@ export default function NewShowDialog({
             setWizardState((prev) => ({
                 ...prev,
                 start: { mode: "importPrevious" },
+                project: {
+                    projectName: prev.project?.projectName ?? "",
+                    fileLocation: prev.project?.fileLocation ?? "",
+                    designer: result.designer,
+                    client: result.client,
+                },
+                ensemble: result.activity
+                    ? { activity: result.activity }
+                    : prev.ensemble,
                 field: {
                     template: fieldTemplate,
                     isCustom: fieldTemplate.isCustom ?? false,

--- a/apps/desktop/src/components/launchpage/NewShowDialog.tsx
+++ b/apps/desktop/src/components/launchpage/NewShowDialog.tsx
@@ -329,6 +329,7 @@ export default function NewShowDialog({
                     ),
                     tags: result.tags,
                     marcherTags: result.marcherTags,
+                    pageNumberOffset: result.pageNumberOffset,
                 },
             }));
             setCompletedSteps((prev) => {

--- a/apps/desktop/src/components/launchpage/NewShowDialog.tsx
+++ b/apps/desktop/src/components/launchpage/NewShowDialog.tsx
@@ -43,6 +43,27 @@ import { conToastError } from "@/utilities/utils";
 import FieldPropertiesTemplates from "@/global/classes/FieldProperties.templates";
 import { DEFAULT_ACTIVITY } from "@/global/classes/Activities";
 import { FieldProperties } from "@openmarch/core";
+import { appearanceModelRawToParsed } from "@/entity-components/appearance";
+import type { NewSectionAppearanceArgs } from "@/db-functions";
+import type { PreviousDotsSectionAppearanceImport } from "@om-electron/main/services/previous-dots-import-service";
+
+function toNewSectionAppearanceArgs(
+    appearance: PreviousDotsSectionAppearanceImport,
+): NewSectionAppearanceArgs {
+    const parsed = appearanceModelRawToParsed({
+        fill_color: appearance.fill_color,
+        outline_color: appearance.outline_color,
+        shape_type: appearance.shape_type,
+        visible: appearance.visible,
+        label_visible: appearance.label_visible,
+        equipment_name: appearance.equipment_name,
+        equipment_state: appearance.equipment_state,
+    });
+    return {
+        section: appearance.section,
+        ...parsed,
+    };
+}
 
 interface NewShowDialogProps {
     open: boolean;
@@ -270,6 +291,12 @@ export default function NewShowDialog({
                 method: result.marchers.length > 0 ? "add" : "skip",
                 marchers: result.marchers,
             };
+            const fieldImage =
+                result.fieldImage != null
+                    ? result.fieldImage instanceof Uint8Array
+                        ? result.fieldImage
+                        : new Uint8Array(result.fieldImage)
+                    : null;
 
             setWizardState((prev) => ({
                 ...prev,
@@ -285,8 +312,14 @@ export default function NewShowDialog({
                         template: fieldTemplate,
                         isCustom: fieldTemplate.isCustom ?? false,
                     },
+                    fieldImage,
                     performers,
                     coordinates: result.coordinates,
+                    sectionAppearances: result.sectionAppearances.map(
+                        toNewSectionAppearanceArgs,
+                    ),
+                    tags: result.tags,
+                    marcherTags: result.marcherTags,
                 },
             }));
             setCompletedSteps((prev) => {

--- a/apps/desktop/src/components/launchpage/NewShowDialog.tsx
+++ b/apps/desktop/src/components/launchpage/NewShowDialog.tsx
@@ -15,6 +15,7 @@ import { T, useTranslate } from "@tolgee/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import NewShowModalLayout from "./newShow/NewShowModalLayout";
+import StartStep from "./newShow/steps/StartStep";
 import ProjectStep from "./newShow/steps/ProjectStep";
 import EnsembleStep from "./newShow/steps/EnsembleStep";
 import FieldStep from "./newShow/steps/FieldStep";
@@ -41,6 +42,7 @@ import { completeNewShow } from "./newShowCompletion";
 import { conToastError } from "@/utilities/utils";
 import FieldPropertiesTemplates from "@/global/classes/FieldProperties.templates";
 import { DEFAULT_ACTIVITY } from "@/global/classes/Activities";
+import { FieldProperties } from "@openmarch/core";
 
 interface NewShowDialogProps {
     open: boolean;
@@ -52,6 +54,10 @@ const STEP_COPY: Record<
     NewShowStepId,
     { titleKey: string; descriptionKey?: string }
 > = {
+    start: {
+        titleKey: "launchpage.newShow.steps.start.title",
+        descriptionKey: "launchpage.newShow.steps.start.description",
+    },
     project: {
         titleKey: "launchpage.newShow.steps.project.title",
         descriptionKey: "launchpage.newShow.steps.project.description",
@@ -78,6 +84,13 @@ const STEP_COPY: Record<
     },
 };
 
+function getWizardSteps(state: NewShowWizardState): NewShowStepId[] {
+    if (state.start?.mode === "importPrevious") {
+        return ["start", "project", "ensemble", "audio", "tempo"];
+    }
+    return NEW_SHOW_STEPS;
+}
+
 export default function NewShowDialog({
     open,
     onOpenChange,
@@ -96,9 +109,13 @@ export default function NewShowDialog({
     const [showExitConfirm, setShowExitConfirm] = useState(false);
     const [isCreatingDraft, setIsCreatingDraft] = useState(false);
 
-    const currentStep = NEW_SHOW_STEPS[currentStepIndex];
+    const wizardSteps = useMemo(
+        () => getWizardSteps(wizardState),
+        [wizardState],
+    );
+    const currentStep = wizardSteps[currentStepIndex] ?? wizardSteps[0];
     const canGoNext = useNewShowValidation(wizardState, currentStep);
-    const isLastStep = currentStepIndex === NEW_SHOW_STEPS.length - 1;
+    const isLastStep = currentStepIndex === wizardSteps.length - 1;
     const isFirstStep = currentStepIndex === 0;
     const canSkip = currentStep === "performers" || currentStep === "audio";
 
@@ -107,6 +124,12 @@ export default function NewShowDialog({
         setCurrentStepIndex(0);
         setCompletedSteps(new Set());
     }, []);
+
+    useEffect(() => {
+        if (currentStepIndex >= wizardSteps.length) {
+            setCurrentStepIndex(wizardSteps.length - 1);
+        }
+    }, [currentStepIndex, wizardSteps.length]);
 
     useEffect(() => {
         if (open) {
@@ -181,7 +204,7 @@ export default function NewShowDialog({
         }
 
         markStepComplete();
-        if (currentStepIndex < NEW_SHOW_STEPS.length - 1) {
+        if (currentStepIndex < wizardSteps.length - 1) {
             setCurrentStepIndex((i) => i + 1);
         }
     }, [
@@ -192,6 +215,7 @@ export default function NewShowDialog({
         ensureDraftCreated,
         markStepComplete,
         currentStepIndex,
+        wizardSteps.length,
     ]);
 
     const handleBack = useCallback(() => {
@@ -217,6 +241,65 @@ export default function NewShowDialog({
             setCurrentStepIndex((i) => i + 1);
         }
     }, [currentStep, isLastStep, markStepComplete]);
+
+    const handleStartBlank = useCallback(() => {
+        setWizardState((prev) => ({
+            ...prev,
+            start: { mode: "blank" },
+            previousDotsImport: undefined,
+            field: null,
+            performers: null,
+        }));
+        setCompletedSteps((prev) => {
+            const next = new Set(prev);
+            next.delete(0);
+            return next;
+        });
+    }, []);
+
+    const handleImportPrevious = useCallback(async () => {
+        setIsCreatingDraft(true);
+        try {
+            const result = await window.electron.choosePreviousDotsFile();
+            if (!result) return;
+
+            const fieldTemplate = new FieldProperties(
+                JSON.parse(result.fieldPropertiesJson),
+            );
+            const performers: NewShowPerformersData = {
+                method: result.marchers.length > 0 ? "add" : "skip",
+                marchers: result.marchers,
+            };
+
+            setWizardState((prev) => ({
+                ...prev,
+                start: { mode: "importPrevious" },
+                field: {
+                    template: fieldTemplate,
+                    isCustom: fieldTemplate.isCustom ?? false,
+                },
+                performers,
+                previousDotsImport: {
+                    sourcePath: result.sourcePath,
+                    field: {
+                        template: fieldTemplate,
+                        isCustom: fieldTemplate.isCustom ?? false,
+                    },
+                    performers,
+                    coordinates: result.coordinates,
+                },
+            }));
+            setCompletedSteps((prev) => {
+                const next = new Set(prev);
+                next.delete(0);
+                return next;
+            });
+        } catch (error) {
+            conToastError(t("launchpage.newShow.errors.importFailed"), error);
+        } finally {
+            setIsCreatingDraft(false);
+        }
+    }, [t]);
 
     const handleComplete = useCallback(async () => {
         if (isCompleting) return;
@@ -306,6 +389,24 @@ export default function NewShowDialog({
 
     const stepContent = useMemo(() => {
         switch (currentStep) {
+            case "start":
+                return (
+                    <StartStep
+                        start={wizardState.start}
+                        importedSourcePath={
+                            wizardState.previousDotsImport?.sourcePath
+                        }
+                        importedPerformerCount={
+                            wizardState.previousDotsImport?.performers.marchers
+                                .length
+                        }
+                        onStartBlank={() => {
+                            handleStartBlank();
+                        }}
+                        onImportPrevious={() => void handleImportPrevious()}
+                        isImporting={isCreatingDraft}
+                    />
+                );
             case "project":
                 return (
                     <ProjectStep
@@ -354,12 +455,17 @@ export default function NewShowDialog({
         }
     }, [
         currentStep,
+        wizardState.start,
         wizardState.project,
         wizardState.ensemble,
         wizardState.field,
         wizardState.performers,
         wizardState.audio,
         wizardState.tempo,
+        wizardState.previousDotsImport,
+        isCreatingDraft,
+        handleStartBlank,
+        handleImportPrevious,
         handleProjectChange,
         handleEnsembleChange,
         handleFieldChange,
@@ -390,6 +496,7 @@ export default function NewShowDialog({
                     </DialogTitle>
                     <NewShowModalLayout
                         currentStepIndex={currentStepIndex}
+                        steps={wizardSteps}
                         stepTitle={t(stepCopy.titleKey)}
                         stepDescription={
                             stepCopy.descriptionKey

--- a/apps/desktop/src/components/launchpage/NewShowDialog.tsx
+++ b/apps/desktop/src/components/launchpage/NewShowDialog.tsx
@@ -268,6 +268,13 @@ export default function NewShowDialog({
             ...prev,
             start: { mode: "blank" },
             previousDotsImport: undefined,
+            project: prev.project
+                ? {
+                      projectName: prev.project.projectName,
+                      fileLocation: prev.project.fileLocation,
+                  }
+                : null,
+            ensemble: null,
             field: null,
             performers: null,
         }));
@@ -309,7 +316,7 @@ export default function NewShowDialog({
                 },
                 ensemble: result.activity
                     ? { activity: result.activity }
-                    : prev.ensemble,
+                    : null,
                 field: {
                     template: fieldTemplate,
                     isCustom: fieldTemplate.isCustom ?? false,

--- a/apps/desktop/src/components/launchpage/__test__/newShowCompletion.test.ts
+++ b/apps/desktop/src/components/launchpage/__test__/newShowCompletion.test.ts
@@ -539,6 +539,7 @@ describeDbTests("completeNewShow", (it) => {
                         tagKey: 20,
                     },
                 ],
+                pageNumberOffset: 18,
             },
         };
 
@@ -619,5 +620,8 @@ describeDbTests("completeNewShow", (it) => {
                 `${t1!.id}:${frontId}`,
             ]),
         );
+
+        const settings = await getWorkspaceSettingsParsed({ db });
+        expect(settings.pageNumberOffset).toBe(18);
     });
 });

--- a/apps/desktop/src/components/launchpage/__test__/newShowCompletion.test.ts
+++ b/apps/desktop/src/components/launchpage/__test__/newShowCompletion.test.ts
@@ -10,7 +10,10 @@ import {
 import { wizardStateToFormState } from "../newShowTypes";
 import type { NewShowWizardState } from "../newShowTypes";
 import { getWorkspaceSettingsParsed } from "@/db-functions/workspaceSettings";
-import { getFieldProperties } from "@/global/classes/FieldProperties";
+import {
+    getFieldProperties,
+    getFieldPropertiesImage,
+} from "@/global/classes/FieldProperties";
 import { allDatabaseBeatsQueryOptions } from "@/hooks/queries/useBeats";
 import { allDatabasePagesQueryOptions } from "@/hooks/queries/usePages";
 import { allDatabaseMeasuresQueryOptions } from "@/hooks/queries/useMeasures";
@@ -18,6 +21,8 @@ import { getUtility } from "@/db-functions/utility";
 import { getMarchers } from "@/db-functions/marcher";
 import { marcherPagesByPageId } from "@/db-functions/marcherPage";
 import { FIRST_PAGE_ID } from "@/db-functions/page";
+import { getSectionAppearances } from "@/db-functions/sectionAppearance";
+import { getMarcherTags, getTags } from "@/db-functions/tag";
 
 describe("newShowCompletion helpers", () => {
     it("sanitizeFilename removes invalid characters", () => {
@@ -152,6 +157,11 @@ describeDbTests("completeNewShow", (it) => {
             "/tmp/Test Show.dots",
             "Test Show",
         );
+
+        expect(await getFieldPropertiesImage()).toBeNull();
+        expect(await getSectionAppearances({ db })).toEqual([]);
+        expect(await getTags({ db })).toEqual([]);
+        expect(await getMarcherTags({ db })).toEqual([]);
     });
 
     it("creates tempo-only show with 3/4 time signature", async ({
@@ -418,6 +428,7 @@ describeDbTests("completeNewShow", (it) => {
     }) => {
         const importedField =
             FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES;
+        const fieldImage = new Uint8Array([1, 2, 3, 4, 5]);
         const wizardState: NewShowWizardState = {
             start: { mode: "importPrevious" },
             project: {
@@ -455,6 +466,7 @@ describeDbTests("completeNewShow", (it) => {
                     template: importedField,
                     isCustom: false,
                 },
+                fieldImage,
                 performers: {
                     method: "add",
                     marchers: [
@@ -482,6 +494,49 @@ describeDbTests("completeNewShow", (it) => {
                         drill_order: 2,
                         x: 987,
                         y: 123,
+                    },
+                ],
+                sectionAppearances: [
+                    {
+                        section: "Trumpet",
+                        fill_color: { r: 255, g: 0, b: 0, a: 1 },
+                        outline_color: { r: 0, g: 0, b: 0, a: 1 },
+                        shape_type: "circle",
+                        visible: true,
+                        label_visible: true,
+                    },
+                ],
+                tags: [
+                    {
+                        key: 10,
+                        name: "Soloists",
+                        description: "Featured performers",
+                        icon: "star",
+                        color_hex: "#ff0000",
+                    },
+                    {
+                        key: 20,
+                        name: "Front",
+                        description: null,
+                        icon: null,
+                        color_hex: "#00ff00",
+                    },
+                ],
+                marcherTags: [
+                    {
+                        drill_prefix: "T",
+                        drill_order: 1,
+                        tagKey: 10,
+                    },
+                    {
+                        drill_prefix: "T",
+                        drill_order: 2,
+                        tagKey: 20,
+                    },
+                    {
+                        drill_prefix: "T",
+                        drill_order: 1,
+                        tagKey: 20,
                     },
                 ],
             },
@@ -519,5 +574,50 @@ describeDbTests("completeNewShow", (it) => {
             x: 987,
             y: 123,
         });
+
+        const importedImage = await getFieldPropertiesImage();
+        expect(importedImage).toEqual(fieldImage);
+
+        const sectionAppearances = await getSectionAppearances({ db });
+        expect(sectionAppearances).toHaveLength(1);
+        expect(sectionAppearances[0]).toMatchObject({
+            section: "Trumpet",
+            fill_color: { r: 255, g: 0, b: 0, a: 1 },
+            outline_color: { r: 0, g: 0, b: 0, a: 1 },
+            shape_type: "circle",
+            visible: true,
+            label_visible: true,
+        });
+
+        const tags = await getTags({ db });
+        expect(tags).toHaveLength(2);
+        const tagByName = new Map(tags.map((tag) => [tag.name, tag]));
+        expect(tagByName.get("Soloists")).toMatchObject({
+            description: "Featured performers",
+            icon: "star",
+            color_hex: "#ff0000",
+        });
+        expect(tagByName.get("Front")).toMatchObject({
+            description: null,
+            icon: null,
+            color_hex: "#00ff00",
+        });
+
+        const marcherTags = await getMarcherTags({ db });
+        expect(marcherTags).toHaveLength(3);
+        const soloistsId = tagByName.get("Soloists")!.id;
+        const frontId = tagByName.get("Front")!.id;
+        const marcherTagKeys = new Set(
+            marcherTags.map(
+                (marcherTag) => `${marcherTag.marcher_id}:${marcherTag.tag_id}`,
+            ),
+        );
+        expect(marcherTagKeys).toEqual(
+            new Set([
+                `${t1!.id}:${soloistsId}`,
+                `${t2!.id}:${frontId}`,
+                `${t1!.id}:${frontId}`,
+            ]),
+        );
     });
 });

--- a/apps/desktop/src/components/launchpage/__test__/newShowCompletion.test.ts
+++ b/apps/desktop/src/components/launchpage/__test__/newShowCompletion.test.ts
@@ -16,6 +16,8 @@ import { allDatabasePagesQueryOptions } from "@/hooks/queries/usePages";
 import { allDatabaseMeasuresQueryOptions } from "@/hooks/queries/useMeasures";
 import { getUtility } from "@/db-functions/utility";
 import { getMarchers } from "@/db-functions/marcher";
+import { marcherPagesByPageId } from "@/db-functions/marcherPage";
+import { FIRST_PAGE_ID } from "@/db-functions/page";
 
 describe("newShowCompletion helpers", () => {
     it("sanitizeFilename removes invalid characters", () => {
@@ -30,6 +32,7 @@ describe("newShowCompletion helpers", () => {
 
     it("maps split audio and tempo wizard state to completion form state", () => {
         const wizardState: NewShowWizardState = {
+            start: { mode: "blank" },
             project: {
                 projectName: "Test Show",
                 fileLocation: "/tmp/test-show.dots",
@@ -85,6 +88,7 @@ describeDbTests("completeNewShow", (it) => {
         db,
     }) => {
         const wizardState: NewShowWizardState = {
+            start: { mode: "blank" },
             project: {
                 projectName: "Test Show",
                 fileLocation: `/tmp/test-show-${task.id}.dots`,
@@ -155,6 +159,7 @@ describeDbTests("completeNewShow", (it) => {
         db,
     }) => {
         const wizardState: NewShowWizardState = {
+            start: { mode: "blank" },
             project: {
                 projectName: "Triple Meter Show",
                 fileLocation: `/tmp/triple-meter-${task.id}.dots`,
@@ -200,6 +205,7 @@ describeDbTests("completeNewShow", (it) => {
         window.electron.getAudioFilesDetails = vi.fn().mockResolvedValue([]);
 
         const wizardState: NewShowWizardState = {
+            start: { mode: "blank" },
             project: {
                 projectName: "Audio Show",
                 fileLocation: `/tmp/audio-show-${task.id}.dots`,
@@ -230,6 +236,7 @@ describeDbTests("completeNewShow", (it) => {
         db: _db,
     }) => {
         const wizardState: NewShowWizardState = {
+            start: { mode: "blank" },
             project: {
                 projectName: "XML Show",
                 fileLocation: `/tmp/xml-show-${task.id}.dots`,
@@ -260,6 +267,7 @@ describeDbTests("completeNewShow", (it) => {
         db,
     }) => {
         const wizardState: NewShowWizardState = {
+            start: { mode: "blank" },
             project: {
                 projectName: "Invalid Tempo Show",
                 fileLocation: `/tmp/invalid-tempo-${task.id}.dots`,
@@ -300,6 +308,7 @@ describeDbTests("completeNewShow", (it) => {
             .mockResolvedValueOnce(200);
 
         const wizardState: NewShowWizardState = {
+            start: { mode: "blank" },
             project: {
                 projectName: "Retry Show",
                 fileLocation: `/tmp/retry-show-${task.id}.dots`,
@@ -355,6 +364,7 @@ describeDbTests("completeNewShow", (it) => {
             .mockResolvedValueOnce(200);
 
         const wizardState: NewShowWizardState = {
+            start: { mode: "blank" },
             project: {
                 projectName: "Performer Retry Show",
                 fileLocation: `/tmp/performer-retry-${task.id}.dots`,
@@ -400,5 +410,114 @@ describeDbTests("completeNewShow", (it) => {
 
         const marchers = await getMarchers({ db });
         expect(marchers).toHaveLength(2);
+    });
+
+    it("applies imported previous dots performers and first-page coordinates", async ({
+        task,
+        db,
+    }) => {
+        const importedField =
+            FieldPropertiesTemplates.COLLEGE_FOOTBALL_FIELD_NO_END_ZONES;
+        const wizardState: NewShowWizardState = {
+            start: { mode: "importPrevious" },
+            project: {
+                projectName: "Imported Previous Show",
+                fileLocation: `/tmp/imported-previous-${task.id}.dots`,
+            },
+            ensemble: {
+                activity: "Marching Band",
+            },
+            field: {
+                template: importedField,
+                isCustom: false,
+            },
+            performers: {
+                method: "add",
+                marchers: [
+                    {
+                        section: "Trumpet",
+                        drill_prefix: "T",
+                        drill_order: 1,
+                    },
+                    {
+                        section: "Trumpet",
+                        drill_prefix: "T",
+                        drill_order: 2,
+                    },
+                ],
+            },
+            audio: { method: "skip" },
+            tempo: { method: "skip" },
+            draftFilePath: "/tmp/draft.dots",
+            previousDotsImport: {
+                sourcePath: "/tmp/source.dots",
+                field: {
+                    template: importedField,
+                    isCustom: false,
+                },
+                performers: {
+                    method: "add",
+                    marchers: [
+                        {
+                            section: "Trumpet",
+                            drill_prefix: "T",
+                            drill_order: 1,
+                        },
+                        {
+                            section: "Trumpet",
+                            drill_prefix: "T",
+                            drill_order: 2,
+                        },
+                    ],
+                },
+                coordinates: [
+                    {
+                        drill_prefix: "T",
+                        drill_order: 1,
+                        x: 321,
+                        y: 654,
+                    },
+                    {
+                        drill_prefix: "T",
+                        drill_order: 2,
+                        x: 987,
+                        y: 123,
+                    },
+                ],
+            },
+        };
+
+        await completeNewShow(wizardStateToFormState(wizardState), queryClient);
+
+        const marchers = await getMarchers({ db });
+        const marcherByDrillNumber = new Map(
+            marchers.map((marcher) => [
+                `${marcher.drill_prefix}${marcher.drill_order}`,
+                marcher,
+            ]),
+        );
+        const firstPageMarcherPages = await marcherPagesByPageId({
+            db,
+            pageId: FIRST_PAGE_ID,
+        });
+        const firstPageByMarcherId = new Map(
+            firstPageMarcherPages.map((marcherPage) => [
+                marcherPage.marcher_id,
+                marcherPage,
+            ]),
+        );
+
+        const t1 = marcherByDrillNumber.get("T1");
+        const t2 = marcherByDrillNumber.get("T2");
+        expect(t1).toBeDefined();
+        expect(t2).toBeDefined();
+        expect(firstPageByMarcherId.get(t1!.id)).toMatchObject({
+            x: 321,
+            y: 654,
+        });
+        expect(firstPageByMarcherId.get(t2!.id)).toMatchObject({
+            x: 987,
+            y: 123,
+        });
     });
 });

--- a/apps/desktop/src/components/launchpage/__test__/parseFromWorkspaceSettings.test.ts
+++ b/apps/desktop/src/components/launchpage/__test__/parseFromWorkspaceSettings.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from "vitest";
 import { parseFromWorkspaceSettings } from "../parseFromWorkspaceSettings";
 
 describe("parseFromWorkspaceSettings", () => {
-    it("returns designer, client, and activity when present", () => {
+    it("returns designer, client, activity, and pageNumberOffset when present", () => {
         expect(
             parseFromWorkspaceSettings(
                 JSON.stringify({
                     designer: "Jane Designer",
                     client: "Acme Band",
                     activity: "Drum Corps",
+                    pageNumberOffset: 12,
                     defaultTempo: 120,
                 }),
             ),
@@ -16,6 +17,7 @@ describe("parseFromWorkspaceSettings", () => {
             designer: "Jane Designer",
             client: "Acme Band",
             activity: "Drum Corps",
+            pageNumberOffset: 12,
         });
     });
 
@@ -32,6 +34,7 @@ describe("parseFromWorkspaceSettings", () => {
             designer: "Jane",
             client: undefined,
             activity: "Winter Guard",
+            pageNumberOffset: undefined,
         });
     });
 
@@ -47,6 +50,7 @@ describe("parseFromWorkspaceSettings", () => {
             designer: undefined,
             client: undefined,
             activity: undefined,
+            pageNumberOffset: undefined,
         });
     });
 
@@ -63,6 +67,61 @@ describe("parseFromWorkspaceSettings", () => {
             designer: undefined,
             client: undefined,
             activity: undefined,
+            pageNumberOffset: undefined,
+        });
+    });
+
+    it("ignores non-integer pageNumberOffset values", () => {
+        expect(
+            parseFromWorkspaceSettings(
+                JSON.stringify({ pageNumberOffset: 1.5 }),
+            ),
+        ).toEqual({
+            designer: undefined,
+            client: undefined,
+            activity: undefined,
+            pageNumberOffset: undefined,
+        });
+        expect(
+            parseFromWorkspaceSettings(
+                JSON.stringify({ pageNumberOffset: "12" }),
+            ),
+        ).toEqual({
+            designer: undefined,
+            client: undefined,
+            activity: undefined,
+            pageNumberOffset: undefined,
+        });
+        expect(
+            parseFromWorkspaceSettings(
+                JSON.stringify({ pageNumberOffset: Number.NaN }),
+            ),
+        ).toEqual({
+            designer: undefined,
+            client: undefined,
+            activity: undefined,
+            pageNumberOffset: undefined,
+        });
+    });
+
+    it("accepts zero and negative integer pageNumberOffset", () => {
+        expect(
+            parseFromWorkspaceSettings(JSON.stringify({ pageNumberOffset: 0 })),
+        ).toEqual({
+            designer: undefined,
+            client: undefined,
+            activity: undefined,
+            pageNumberOffset: 0,
+        });
+        expect(
+            parseFromWorkspaceSettings(
+                JSON.stringify({ pageNumberOffset: -3 }),
+            ),
+        ).toEqual({
+            designer: undefined,
+            client: undefined,
+            activity: undefined,
+            pageNumberOffset: -3,
         });
     });
 });

--- a/apps/desktop/src/components/launchpage/__test__/parseFromWorkspaceSettings.test.ts
+++ b/apps/desktop/src/components/launchpage/__test__/parseFromWorkspaceSettings.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { parseFromWorkspaceSettings } from "../parseFromWorkspaceSettings";
+
+describe("parseFromWorkspaceSettings", () => {
+    it("returns designer, client, and activity when present", () => {
+        expect(
+            parseFromWorkspaceSettings(
+                JSON.stringify({
+                    designer: "Jane Designer",
+                    client: "Acme Band",
+                    activity: "Drum Corps",
+                    defaultTempo: 120,
+                }),
+            ),
+        ).toEqual({
+            designer: "Jane Designer",
+            client: "Acme Band",
+            activity: "Drum Corps",
+        });
+    });
+
+    it("trims whitespace and omits empty strings", () => {
+        expect(
+            parseFromWorkspaceSettings(
+                JSON.stringify({
+                    designer: "  Jane  ",
+                    client: "   ",
+                    activity: "  Winter Guard  ",
+                }),
+            ),
+        ).toEqual({
+            designer: "Jane",
+            client: undefined,
+            activity: "Winter Guard",
+        });
+    });
+
+    it("returns empty object when settings are missing or invalid", () => {
+        expect(parseFromWorkspaceSettings(undefined)).toEqual({});
+        expect(parseFromWorkspaceSettings(null)).toEqual({});
+        expect(parseFromWorkspaceSettings("")).toEqual({});
+        expect(parseFromWorkspaceSettings("not-json")).toEqual({});
+        expect(parseFromWorkspaceSettings("[]")).toEqual({});
+        expect(
+            parseFromWorkspaceSettings(JSON.stringify({ defaultTempo: 120 })),
+        ).toEqual({
+            designer: undefined,
+            client: undefined,
+            activity: undefined,
+        });
+    });
+
+    it("ignores non-string designer, client, and activity values", () => {
+        expect(
+            parseFromWorkspaceSettings(
+                JSON.stringify({
+                    designer: 42,
+                    client: { name: "Acme" },
+                    activity: ["Marching Band"],
+                }),
+            ),
+        ).toEqual({
+            designer: undefined,
+            client: undefined,
+            activity: undefined,
+        });
+    });
+});

--- a/apps/desktop/src/components/launchpage/newShow/NewShowModalLayout.tsx
+++ b/apps/desktop/src/components/launchpage/newShow/NewShowModalLayout.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 import NewShowProgressIndicator from "./components/NewShowProgressIndicator";
 import NewShowNavigationButtons from "./components/NewShowNavigationButtons";
-import type { NewShowStepId } from "./newShowTypes";
+import { NewShowStepId } from "../newShowTypes";
 
 interface NewShowModalLayoutProps {
     currentStepIndex: number;

--- a/apps/desktop/src/components/launchpage/newShow/NewShowModalLayout.tsx
+++ b/apps/desktop/src/components/launchpage/newShow/NewShowModalLayout.tsx
@@ -1,9 +1,11 @@
 import { ReactNode } from "react";
 import NewShowProgressIndicator from "./components/NewShowProgressIndicator";
 import NewShowNavigationButtons from "./components/NewShowNavigationButtons";
+import type { NewShowStepId } from "./newShowTypes";
 
 interface NewShowModalLayoutProps {
     currentStepIndex: number;
+    steps: NewShowStepId[];
     stepTitle: string;
     stepDescription?: string;
     children: ReactNode;
@@ -22,6 +24,7 @@ interface NewShowModalLayoutProps {
 
 export default function NewShowModalLayout({
     currentStepIndex,
+    steps,
     stepTitle,
     stepDescription,
     children,
@@ -41,6 +44,7 @@ export default function NewShowModalLayout({
         <div className="flex min-h-0 flex-col gap-16">
             <NewShowProgressIndicator
                 currentStepIndex={currentStepIndex}
+                steps={steps}
                 completedSteps={completedSteps}
             />
             <div className="text-center">

--- a/apps/desktop/src/components/launchpage/newShow/__test__/useNewShowValidation.test.ts
+++ b/apps/desktop/src/components/launchpage/newShow/__test__/useNewShowValidation.test.ts
@@ -8,6 +8,22 @@ import {
 import FieldPropertiesTemplates from "@/global/classes/FieldProperties.templates";
 
 describe("useNewShowValidation", () => {
+    it("requires a setup mode on start step", () => {
+        const { result } = renderHook(() =>
+            useNewShowValidation(DEFAULT_NEW_SHOW_WIZARD_STATE, "start"),
+        );
+        expect(result.current).toBe(false);
+
+        const withStart: NewShowWizardState = {
+            ...DEFAULT_NEW_SHOW_WIZARD_STATE,
+            start: { mode: "importPrevious" },
+        };
+        const { result: selectedResult } = renderHook(() =>
+            useNewShowValidation(withStart, "start"),
+        );
+        expect(selectedResult.current).toBe(true);
+    });
+
     it("requires project name and file location on project step", () => {
         const { result } = renderHook(() =>
             useNewShowValidation(DEFAULT_NEW_SHOW_WIZARD_STATE, "project"),

--- a/apps/desktop/src/components/launchpage/newShow/components/NewShowProgressIndicator.tsx
+++ b/apps/desktop/src/components/launchpage/newShow/components/NewShowProgressIndicator.tsx
@@ -1,18 +1,20 @@
-import { NEW_SHOW_STEPS } from "../../newShowTypes";
+import type { NewShowStepId } from "../../newShowTypes";
 import clsx from "clsx";
 
 interface NewShowProgressIndicatorProps {
     currentStepIndex: number;
+    steps: NewShowStepId[];
     completedSteps: ReadonlySet<number>;
 }
 
 export default function NewShowProgressIndicator({
     currentStepIndex,
+    steps,
     completedSteps,
 }: NewShowProgressIndicatorProps) {
     return (
         <div className="flex w-full items-center justify-center gap-8 px-8">
-            {NEW_SHOW_STEPS.map((_, index) => (
+            {steps.map((_, index) => (
                 <div
                     key={index}
                     className={clsx(

--- a/apps/desktop/src/components/launchpage/newShow/hooks/useNewShowValidation.ts
+++ b/apps/desktop/src/components/launchpage/newShow/hooks/useNewShowValidation.ts
@@ -21,6 +21,8 @@ export function useNewShowValidation(
         }
 
         switch (currentStep) {
+            case "start":
+                return state.start !== null;
             case "project": {
                 const project = state.project;
                 return (

--- a/apps/desktop/src/components/launchpage/newShow/steps/StartStep.tsx
+++ b/apps/desktop/src/components/launchpage/newShow/steps/StartStep.tsx
@@ -1,7 +1,13 @@
 import { Button } from "@openmarch/ui";
 import { T, useTranslate } from "@tolgee/react";
-import { FileArrowUpIcon, FilePlusIcon } from "@phosphor-icons/react";
+import {
+    DownloadSimpleIcon,
+    FileArrowUpIcon,
+    FileIcon,
+    FilePlusIcon,
+} from "@phosphor-icons/react";
 import type { NewShowStartData } from "../../newShowTypes";
+import clsx from "clsx";
 
 interface StartStepProps {
     start: NewShowStartData | null;
@@ -26,52 +32,59 @@ export default function StartStep({
 
     return (
         <div className="mx-auto flex w-full max-w-lg flex-col gap-12">
-            <Button
-                type="button"
-                variant={selectedMode === "blank" ? "primary" : "secondary"}
-                className="h-auto justify-start gap-12 p-16 text-left"
-                onClick={onStartBlank}
-                disabled={isImporting}
+            <div
+                tabIndex={isImporting ? -1 : 0}
+                className={clsx(
+                    "rounded-6 h-auto justify-start gap-12 border p-16 text-left",
+                    selectedMode === "blank"
+                        ? "bg-accent/20 border-accent"
+                        : "bg-fg-2 border-stroke",
+                    isImporting
+                        ? "pointer-events-none opacity-50"
+                        : "cursor-pointer",
+                )}
+                onClick={isImporting ? undefined : onStartBlank}
             >
-                <FilePlusIcon size={28} />
-                <span className="flex flex-col gap-4">
-                    <span className="text-body font-medium">
+                <span className="flex items-center gap-8">
+                    <FileIcon size={28} />
+                    <span className="text-lg font-bold">
                         <T keyName="launchpage.newShow.steps.start.blank" />
                     </span>
-                    <span className="text-text/70 text-sm font-normal">
-                        <T keyName="launchpage.newShow.steps.start.blankDescription" />
-                    </span>
                 </span>
-            </Button>
-            <Button
-                type="button"
-                variant={
-                    selectedMode === "importPrevious" ? "primary" : "secondary"
-                }
-                className="h-auto justify-start gap-12 p-16 text-left"
-                onClick={onImportPrevious}
-                disabled={isImporting}
+                <span className="text-text/70 text-sm font-normal">
+                    <T keyName="launchpage.newShow.steps.start.blankDescription" />
+                </span>
+            </div>
+            <div
+                tabIndex={isImporting ? -1 : 0}
+                className={clsx(
+                    "rounded-6 h-auto justify-start gap-12 border p-16 text-left",
+                    selectedMode === "importPrevious"
+                        ? "bg-accent/20 border-accent"
+                        : "bg-fg-2 border-stroke",
+                    isImporting
+                        ? "pointer-events-none opacity-50"
+                        : "cursor-pointer",
+                )}
+                onClick={isImporting ? undefined : onImportPrevious}
             >
-                <FileArrowUpIcon size={28} />
-                <span className="flex flex-col gap-4">
-                    <span className="text-body font-medium">
+                <span className="flex items-center gap-8">
+                    <DownloadSimpleIcon size={28} />
+                    <span className="text-lg font-bold">
                         <T keyName="launchpage.newShow.steps.start.importPrevious" />
                     </span>
-                    <span className="text-text/70 text-sm font-normal">
-                        {sourceName
-                            ? t(
-                                  "launchpage.newShow.steps.start.importSummary",
-                                  {
-                                      fileName: sourceName,
-                                      count: importedPerformerCount ?? 0,
-                                  },
-                              )
-                            : t(
-                                  "launchpage.newShow.steps.start.importPreviousDescription",
-                              )}
-                    </span>
                 </span>
-            </Button>
+                <span className="text-text/70 text-sm font-normal">
+                    {sourceName
+                        ? t("launchpage.newShow.steps.start.importSummary", {
+                              fileName: sourceName,
+                              count: importedPerformerCount ?? 0,
+                          })
+                        : t(
+                              "launchpage.newShow.steps.start.importPreviousDescription",
+                          )}
+                </span>
+            </div>
         </div>
     );
 }

--- a/apps/desktop/src/components/launchpage/newShow/steps/StartStep.tsx
+++ b/apps/desktop/src/components/launchpage/newShow/steps/StartStep.tsx
@@ -1,11 +1,6 @@
-import { Button } from "@openmarch/ui";
 import { T, useTranslate } from "@tolgee/react";
-import {
-    DownloadSimpleIcon,
-    FileArrowUpIcon,
-    FileIcon,
-    FilePlusIcon,
-} from "@phosphor-icons/react";
+import { DownloadSimpleIcon, FileIcon } from "@phosphor-icons/react";
+import type { KeyboardEvent } from "react";
 import type { NewShowStartData } from "../../newShowTypes";
 import clsx from "clsx";
 
@@ -30,9 +25,18 @@ export default function StartStep({
     const selectedMode = start?.mode;
     const sourceName = importedSourcePath?.split(/[\\/]/).pop();
 
+    const handleCardKeyDown = (event: KeyboardEvent, onSelect: () => void) => {
+        if (isImporting) return;
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onSelect();
+        }
+    };
+
     return (
         <div className="mx-auto flex w-full max-w-lg flex-col gap-12">
             <div
+                role="button"
                 tabIndex={isImporting ? -1 : 0}
                 className={clsx(
                     "rounded-6 h-auto justify-start gap-12 border p-16 text-left",
@@ -44,6 +48,7 @@ export default function StartStep({
                         : "cursor-pointer",
                 )}
                 onClick={isImporting ? undefined : onStartBlank}
+                onKeyDown={(e) => handleCardKeyDown(e, onStartBlank)}
             >
                 <span className="flex items-center gap-8">
                     <FileIcon size={28} />
@@ -56,6 +61,7 @@ export default function StartStep({
                 </span>
             </div>
             <div
+                role="button"
                 tabIndex={isImporting ? -1 : 0}
                 className={clsx(
                     "rounded-6 h-auto justify-start gap-12 border p-16 text-left",
@@ -67,6 +73,7 @@ export default function StartStep({
                         : "cursor-pointer",
                 )}
                 onClick={isImporting ? undefined : onImportPrevious}
+                onKeyDown={(e) => handleCardKeyDown(e, onImportPrevious)}
             >
                 <span className="flex items-center gap-8">
                     <DownloadSimpleIcon size={28} />

--- a/apps/desktop/src/components/launchpage/newShow/steps/StartStep.tsx
+++ b/apps/desktop/src/components/launchpage/newShow/steps/StartStep.tsx
@@ -1,0 +1,77 @@
+import { Button } from "@openmarch/ui";
+import { T, useTranslate } from "@tolgee/react";
+import { FileArrowUpIcon, FilePlusIcon } from "@phosphor-icons/react";
+import type { NewShowStartData } from "../../newShowTypes";
+
+interface StartStepProps {
+    start: NewShowStartData | null;
+    importedSourcePath?: string;
+    importedPerformerCount?: number;
+    onStartBlank: () => void;
+    onImportPrevious: () => void;
+    isImporting?: boolean;
+}
+
+export default function StartStep({
+    start,
+    importedSourcePath,
+    importedPerformerCount,
+    onStartBlank,
+    onImportPrevious,
+    isImporting = false,
+}: StartStepProps) {
+    const { t } = useTranslate();
+    const selectedMode = start?.mode;
+    const sourceName = importedSourcePath?.split(/[\\/]/).pop();
+
+    return (
+        <div className="mx-auto flex w-full max-w-lg flex-col gap-12">
+            <Button
+                type="button"
+                variant={selectedMode === "blank" ? "primary" : "secondary"}
+                className="h-auto justify-start gap-12 p-16 text-left"
+                onClick={onStartBlank}
+                disabled={isImporting}
+            >
+                <FilePlusIcon size={28} />
+                <span className="flex flex-col gap-4">
+                    <span className="text-body font-medium">
+                        <T keyName="launchpage.newShow.steps.start.blank" />
+                    </span>
+                    <span className="text-text/70 text-sm font-normal">
+                        <T keyName="launchpage.newShow.steps.start.blankDescription" />
+                    </span>
+                </span>
+            </Button>
+            <Button
+                type="button"
+                variant={
+                    selectedMode === "importPrevious" ? "primary" : "secondary"
+                }
+                className="h-auto justify-start gap-12 p-16 text-left"
+                onClick={onImportPrevious}
+                disabled={isImporting}
+            >
+                <FileArrowUpIcon size={28} />
+                <span className="flex flex-col gap-4">
+                    <span className="text-body font-medium">
+                        <T keyName="launchpage.newShow.steps.start.importPrevious" />
+                    </span>
+                    <span className="text-text/70 text-sm font-normal">
+                        {sourceName
+                            ? t(
+                                  "launchpage.newShow.steps.start.importSummary",
+                                  {
+                                      fileName: sourceName,
+                                      count: importedPerformerCount ?? 0,
+                                  },
+                              )
+                            : t(
+                                  "launchpage.newShow.steps.start.importPreviousDescription",
+                              )}
+                    </span>
+                </span>
+            </Button>
+        </div>
+    );
+}

--- a/apps/desktop/src/components/launchpage/newShowCompletion.ts
+++ b/apps/desktop/src/components/launchpage/newShowCompletion.ts
@@ -166,6 +166,9 @@ async function applyProjectSettings(form: NewShowFormState): Promise<void> {
         defaultBeatsPerMeasure,
         defaultNewPageCounts: getDefaultNewPageCounts(form),
         activity: form.ensemble?.activity,
+        ...(form.previousDotsImport != null
+            ? { pageNumberOffset: form.previousDotsImport.pageNumberOffset }
+            : {}),
     });
     await updateWorkspaceSettingsParsed({ db, settings: updatedSettings });
 }

--- a/apps/desktop/src/components/launchpage/newShowCompletion.ts
+++ b/apps/desktop/src/components/launchpage/newShowCompletion.ts
@@ -38,11 +38,13 @@ import { createAllUndoTriggers } from "@/db-functions/history";
 import { databaseReadyQueryOptions } from "@/hooks/useDatabaseReady";
 import { fieldPropertiesKeys } from "@/hooks/queries/useFieldProperties";
 import { workspaceSettingsKeys } from "@/hooks/queries/useWorkspaceSettings";
+import { marcherPageKeys } from "@/hooks/queries/useMarcherPages";
 import {
     createMarchers,
     deleteMarchers,
     getMarchers,
 } from "@/db-functions/marcher";
+import { updateMarcherPagesInTransaction } from "@/db-functions/marcherPage";
 import AudioFile from "@/global/classes/AudioFile";
 import {
     deleteMeasuresInTransaction,
@@ -244,6 +246,61 @@ async function applyPerformersSettings(
 
     await queryClient.invalidateQueries({
         queryKey: allMarchersQueryOptions().queryKey,
+    });
+    await queryClient.invalidateQueries({
+        queryKey: marcherPageKeys.all(),
+    });
+}
+
+function drillNumberKey(marcher: {
+    drill_prefix: string;
+    drill_order: number;
+}): string {
+    return `${marcher.drill_prefix}\u0000${marcher.drill_order}`;
+}
+
+async function applyPreviousDotsCoordinates(
+    form: NewShowFormState,
+    queryClient: QueryClient,
+): Promise<void> {
+    const coordinates = form.previousDotsImport?.coordinates;
+    if (!coordinates?.length) return;
+
+    const coordinateByDrillNumber = new Map(
+        coordinates.map((coordinate) => [
+            drillNumberKey(coordinate),
+            coordinate,
+        ]),
+    );
+    const marchers = await getMarchers({ db });
+    const updates = marchers.flatMap((marcher) => {
+        const coordinate = coordinateByDrillNumber.get(drillNumberKey(marcher));
+        if (!coordinate) return [];
+        return [
+            {
+                marcher_id: marcher.id,
+                page_id: FIRST_PAGE_ID,
+                x: coordinate.x,
+                y: coordinate.y,
+            },
+        ];
+    });
+
+    if (updates.length === 0) return;
+
+    await transactionWithHistory(
+        db,
+        "applyPreviousDotsCoordinates",
+        async (tx) => {
+            await updateMarcherPagesInTransaction({
+                tx,
+                modifiedMarcherPages: updates,
+            });
+        },
+    );
+
+    await queryClient.invalidateQueries({
+        queryKey: marcherPageKeys.all(),
     });
 }
 
@@ -573,6 +630,7 @@ export async function completeNewShow(
         await createBeatsAndPages(queryClient);
     }
     await applyPerformersSettings(form.performers, queryClient);
+    await applyPreviousDotsCoordinates(form, queryClient);
 
     const finalizeResult = await window.electron.finalizeNewShowDraft(
         targetPath,

--- a/apps/desktop/src/components/launchpage/newShowCompletion.ts
+++ b/apps/desktop/src/components/launchpage/newShowCompletion.ts
@@ -51,7 +51,10 @@ import {
 } from "@/db-functions/marcher";
 import { updateMarcherPagesInTransaction } from "@/db-functions/marcherPage";
 import { createSectionAppearances } from "@/db-functions/sectionAppearance";
-import { createMarcherTags, createTags } from "@/db-functions/tag";
+import {
+    _createTagsInTransaction,
+    createMarcherTags,
+} from "@/db-functions/tag";
 import AudioFile from "@/global/classes/AudioFile";
 import {
     deleteMeasuresInTransaction,
@@ -350,19 +353,23 @@ async function applyPreviousDotsMarcherTags(
     const importData = form.previousDotsImport;
     if (!importData?.tags.length) return;
 
-    const createdTags = await createTags({
-        db,
-        newTags: importData.tags.map((tag) => ({
-            name: tag.name,
-            description: tag.description,
-            icon: tag.icon,
-            color_hex: tag.color_hex,
-        })),
+    const tagIdByKey = new Map<number, number>();
+    await transactionWithHistory(db, "createTags", async (tx) => {
+        for (const tag of importData.tags) {
+            const [createdTag] = await _createTagsInTransaction({
+                tx,
+                newTags: [
+                    {
+                        name: tag.name,
+                        description: tag.description,
+                        icon: tag.icon,
+                        color_hex: tag.color_hex,
+                    },
+                ],
+            });
+            tagIdByKey.set(tag.key, createdTag.id);
+        }
     });
-
-    const tagIdByKey = new Map(
-        importData.tags.map((tag, index) => [tag.key, createdTags[index].id]),
-    );
 
     if (!importData.marcherTags.length) {
         await queryClient.invalidateQueries({

--- a/apps/desktop/src/components/launchpage/newShowCompletion.ts
+++ b/apps/desktop/src/components/launchpage/newShowCompletion.ts
@@ -14,7 +14,10 @@ import {
     FIRST_PAGE_ID,
 } from "@/db-functions/page";
 import { transactionWithHistory } from "@/db-functions/history";
-import { updateFieldProperties } from "@/global/classes/FieldProperties";
+import {
+    updateFieldProperties,
+    updateFieldPropertiesImage,
+} from "@/global/classes/FieldProperties";
 import {
     updateWorkspaceSettingsParsed,
     getWorkspaceSettingsParsed,
@@ -39,12 +42,16 @@ import { databaseReadyQueryOptions } from "@/hooks/useDatabaseReady";
 import { fieldPropertiesKeys } from "@/hooks/queries/useFieldProperties";
 import { workspaceSettingsKeys } from "@/hooks/queries/useWorkspaceSettings";
 import { marcherPageKeys } from "@/hooks/queries/useMarcherPages";
+import { sectionAppearanceKeys } from "@/hooks/queries/useSectionAppearances";
+import { tagKeys } from "@/hooks/queries/tags/queries";
 import {
     createMarchers,
     deleteMarchers,
     getMarchers,
 } from "@/db-functions/marcher";
 import { updateMarcherPagesInTransaction } from "@/db-functions/marcherPage";
+import { createSectionAppearances } from "@/db-functions/sectionAppearance";
+import { createMarcherTags, createTags } from "@/db-functions/tag";
 import AudioFile from "@/global/classes/AudioFile";
 import {
     deleteMeasuresInTransaction,
@@ -301,6 +308,92 @@ async function applyPreviousDotsCoordinates(
 
     await queryClient.invalidateQueries({
         queryKey: marcherPageKeys.all(),
+    });
+}
+
+async function applyPreviousDotsFieldImage(
+    form: NewShowFormState,
+    queryClient: QueryClient,
+): Promise<void> {
+    const fieldImage = form.previousDotsImport?.fieldImage;
+    if (fieldImage == null || fieldImage.length === 0) return;
+
+    await updateFieldPropertiesImage(fieldImage);
+    await queryClient.invalidateQueries({
+        queryKey: fieldPropertiesKeys.detail(),
+    });
+}
+
+async function applyPreviousDotsSectionAppearances(
+    form: NewShowFormState,
+    queryClient: QueryClient,
+): Promise<void> {
+    const sectionAppearances = form.previousDotsImport?.sectionAppearances;
+    if (!sectionAppearances?.length) return;
+
+    await createSectionAppearances({
+        db,
+        newItems: sectionAppearances,
+    });
+    await queryClient.invalidateQueries({
+        queryKey: sectionAppearanceKeys.all(),
+    });
+}
+
+async function applyPreviousDotsMarcherTags(
+    form: NewShowFormState,
+    queryClient: QueryClient,
+): Promise<void> {
+    const importData = form.previousDotsImport;
+    if (!importData?.tags.length) return;
+
+    const createdTags = await createTags({
+        db,
+        newTags: importData.tags.map((tag) => ({
+            name: tag.name,
+            description: tag.description,
+            icon: tag.icon,
+            color_hex: tag.color_hex,
+        })),
+    });
+
+    const tagIdByKey = new Map(
+        importData.tags.map((tag, index) => [tag.key, createdTags[index].id]),
+    );
+
+    if (!importData.marcherTags.length) {
+        await queryClient.invalidateQueries({
+            queryKey: tagKeys.allTags(),
+        });
+        return;
+    }
+
+    const marchers = await getMarchers({ db });
+    const marcherIdByDrillNumber = new Map(
+        marchers.map((marcher) => [drillNumberKey(marcher), marcher.id]),
+    );
+
+    const newMarcherTags = importData.marcherTags.flatMap((marcherTag) => {
+        const marcherId = marcherIdByDrillNumber.get(
+            drillNumberKey(marcherTag),
+        );
+        const tagId = tagIdByKey.get(marcherTag.tagKey);
+        if (marcherId == null || tagId == null) return [];
+        return [{ marcher_id: marcherId, tag_id: tagId }];
+    });
+
+    if (newMarcherTags.length > 0) {
+        await createMarcherTags({ db, newMarcherTags });
+    }
+
+    await queryClient.invalidateQueries({
+        queryKey: tagKeys.allTags(),
+    });
+    await queryClient.invalidateQueries({
+        queryKey: tagKeys.allMarcherTags(),
+    });
+    await queryClient.invalidateQueries({
+        queryKey: tagKeys.marcherIdsByTagIdMap(),
     });
 }
 
@@ -624,6 +717,7 @@ export async function completeNewShow(
     await applyProjectSettings(form);
     await applyMusicSettings(form.audio, form.tempo);
     await updateFieldProperties(form.fieldTemplate);
+    await applyPreviousDotsFieldImage(form, queryClient);
     if (form.tempo?.method === "tempo_only") {
         await createTempoOnlyBeatsMeasuresAndPages(form, queryClient);
     } else {
@@ -631,6 +725,8 @@ export async function completeNewShow(
     }
     await applyPerformersSettings(form.performers, queryClient);
     await applyPreviousDotsCoordinates(form, queryClient);
+    await applyPreviousDotsSectionAppearances(form, queryClient);
+    await applyPreviousDotsMarcherTags(form, queryClient);
 
     const finalizeResult = await window.electron.finalizeNewShowDraft(
         targetPath,

--- a/apps/desktop/src/components/launchpage/newShowTypes.ts
+++ b/apps/desktop/src/components/launchpage/newShowTypes.ts
@@ -2,6 +2,7 @@ import type { FieldProperties } from "@openmarch/core";
 import type { NewMarcherArgs } from "@/db-functions";
 
 export type NewShowStepId =
+    | "start"
     | "project"
     | "ensemble"
     | "field"
@@ -10,6 +11,7 @@ export type NewShowStepId =
     | "tempo";
 
 export const NEW_SHOW_STEPS: NewShowStepId[] = [
+    "start",
     "project",
     "ensemble",
     "field",
@@ -25,6 +27,12 @@ export interface NewShowProjectData {
     client?: string;
 }
 
+export type NewShowSetupMode = "blank" | "importPrevious";
+
+export interface NewShowStartData {
+    mode: NewShowSetupMode;
+}
+
 export interface NewShowEnsembleData {
     activity: string;
 }
@@ -32,6 +40,20 @@ export interface NewShowEnsembleData {
 export interface NewShowFieldData {
     template: FieldProperties;
     isCustom: boolean;
+}
+
+export interface PreviousDotsCoordinateData {
+    drill_prefix: string;
+    drill_order: number;
+    x: number;
+    y: number;
+}
+
+export interface PreviousDotsImportData {
+    sourcePath: string;
+    field: NewShowFieldData;
+    performers: NewShowPerformersData;
+    coordinates: PreviousDotsCoordinateData[];
 }
 
 export type NewShowMarcherDraft = NewMarcherArgs & { tempId?: string };
@@ -79,6 +101,7 @@ export interface NewShowTempoData {
 }
 
 export interface NewShowWizardState {
+    start: NewShowStartData | null;
     project: NewShowProjectData | null;
     ensemble: NewShowEnsembleData | null;
     field: NewShowFieldData | null;
@@ -86,9 +109,11 @@ export interface NewShowWizardState {
     audio: NewShowAudioData | null;
     tempo: NewShowTempoData | null;
     draftFilePath?: string;
+    previousDotsImport?: PreviousDotsImportData;
 }
 
 export const DEFAULT_NEW_SHOW_WIZARD_STATE: NewShowWizardState = {
+    start: null,
     project: null,
     ensemble: null,
     field: null,
@@ -110,6 +135,7 @@ export type NewShowFormState = {
     audio?: NewShowAudioData | null;
     tempo?: NewShowTempoData | null;
     draftFilePath?: string;
+    previousDotsImport?: PreviousDotsImportData;
 };
 
 export function wizardStateToFormState(
@@ -135,11 +161,13 @@ export function wizardStateToFormState(
         audio: state.audio,
         tempo: state.tempo,
         draftFilePath: state.draftFilePath,
+        previousDotsImport: state.previousDotsImport,
     };
 }
 
 export function hasNewShowProgress(state: NewShowWizardState): boolean {
     return (
+        state.start !== null ||
         state.project !== null ||
         state.ensemble !== null ||
         state.field !== null ||

--- a/apps/desktop/src/components/launchpage/newShowTypes.ts
+++ b/apps/desktop/src/components/launchpage/newShowTypes.ts
@@ -1,5 +1,5 @@
 import type { FieldProperties } from "@openmarch/core";
-import type { NewMarcherArgs } from "@/db-functions";
+import type { NewMarcherArgs, NewSectionAppearanceArgs } from "@/db-functions";
 
 export type NewShowStepId =
     | "start"
@@ -49,11 +49,29 @@ export interface PreviousDotsCoordinateData {
     y: number;
 }
 
+export interface PreviousDotsTagData {
+    key: number;
+    name?: string | null;
+    description?: string | null;
+    icon?: string | null;
+    color_hex?: string | null;
+}
+
+export interface PreviousDotsMarcherTagData {
+    drill_prefix: string;
+    drill_order: number;
+    tagKey: number;
+}
+
 export interface PreviousDotsImportData {
     sourcePath: string;
     field: NewShowFieldData;
+    fieldImage?: Uint8Array | null;
     performers: NewShowPerformersData;
     coordinates: PreviousDotsCoordinateData[];
+    sectionAppearances: NewSectionAppearanceArgs[];
+    tags: PreviousDotsTagData[];
+    marcherTags: PreviousDotsMarcherTagData[];
 }
 
 export type NewShowMarcherDraft = NewMarcherArgs & { tempId?: string };

--- a/apps/desktop/src/components/launchpage/newShowTypes.ts
+++ b/apps/desktop/src/components/launchpage/newShowTypes.ts
@@ -72,6 +72,8 @@ export interface PreviousDotsImportData {
     sectionAppearances: NewSectionAppearanceArgs[];
     tags: PreviousDotsTagData[];
     marcherTags: PreviousDotsMarcherTagData[];
+    /** Last named page number from the source file; applied as pageNumberOffset. */
+    pageNumberOffset: number;
 }
 
 export type NewShowMarcherDraft = NewMarcherArgs & { tempId?: string };

--- a/apps/desktop/src/components/launchpage/parseFromWorkspaceSettings.ts
+++ b/apps/desktop/src/components/launchpage/parseFromWorkspaceSettings.ts
@@ -1,7 +1,12 @@
 /** Extract non-empty trimmed fields from workspace_settings JSON. */
 export function parseFromWorkspaceSettings(
     jsonData: string | null | undefined,
-): { designer?: string; client?: string; activity?: string } {
+): {
+    designer?: string;
+    client?: string;
+    activity?: string;
+    pageNumberOffset?: number;
+} {
     if (!jsonData) return {};
 
     try {
@@ -21,8 +26,14 @@ export function parseFromWorkspaceSettings(
             typeof record.activity === "string"
                 ? record.activity.trim() || undefined
                 : undefined;
+        const pageNumberOffset =
+            typeof record.pageNumberOffset === "number" &&
+            Number.isFinite(record.pageNumberOffset) &&
+            Number.isInteger(record.pageNumberOffset)
+                ? record.pageNumberOffset
+                : undefined;
 
-        return { designer, client, activity };
+        return { designer, client, activity, pageNumberOffset };
     } catch {
         return {};
     }

--- a/apps/desktop/src/components/launchpage/parseFromWorkspaceSettings.ts
+++ b/apps/desktop/src/components/launchpage/parseFromWorkspaceSettings.ts
@@ -1,0 +1,29 @@
+/** Extract non-empty trimmed fields from workspace_settings JSON. */
+export function parseFromWorkspaceSettings(
+    jsonData: string | null | undefined,
+): { designer?: string; client?: string; activity?: string } {
+    if (!jsonData) return {};
+
+    try {
+        const parsed: unknown = JSON.parse(jsonData);
+        if (typeof parsed !== "object" || parsed === null) return {};
+
+        const record = parsed as Record<string, unknown>;
+        const designer =
+            typeof record.designer === "string"
+                ? record.designer.trim() || undefined
+                : undefined;
+        const client =
+            typeof record.client === "string"
+                ? record.client.trim() || undefined
+                : undefined;
+        const activity =
+            typeof record.activity === "string"
+                ? record.activity.trim() || undefined
+                : undefined;
+
+        return { designer, client, activity };
+    } catch {
+        return {};
+    }
+}

--- a/apps/desktop/src/db-functions/sectionAppearance.ts
+++ b/apps/desktop/src/db-functions/sectionAppearance.ts
@@ -51,8 +51,8 @@ const newSectionAppearanceArgsToRealNewSectionAppearanceArgs = (
         section: args.section,
         ...appearanceModelParsedToRawOptional({
             ...args,
-            visible: true,
-            label_visible: true,
+            visible: args.visible ?? true,
+            label_visible: args.label_visible ?? true,
         }),
     };
 };

--- a/apps/desktop/src/db-functions/tag.ts
+++ b/apps/desktop/src/db-functions/tag.ts
@@ -30,12 +30,16 @@ export const getTagName = (tag: { tag_id: number; name?: string | null }) =>
 export interface NewTagArgs {
     name?: string | null;
     description?: string | null;
+    icon?: string | null;
+    color_hex?: string | null;
 }
 
 export interface ModifiedTagArgs {
     id: number;
     name?: string | null;
     description?: string | null;
+    icon?: string | null;
+    color_hex?: string | null;
 }
 
 /**

--- a/apps/desktop/src/global/classes/Page.ts
+++ b/apps/desktop/src/global/classes/Page.ts
@@ -365,6 +365,25 @@ export const generatePageNames = (
 };
 
 /**
+ * Returns the numeric part of the last page name for an ordered subset list.
+ *
+ * This is the last named page number (e.g. 3 from "3" or "3B"), not the page count.
+ * Empty input returns `pageNumberOffset`.
+ */
+export const getLastPageNumber = (
+    isSubsetArr: boolean[],
+    pageNumberOffset: number = 0,
+): number => {
+    if (isSubsetArr.length === 0) return pageNumberOffset;
+
+    const pageNames = generatePageNames(isSubsetArr, pageNumberOffset);
+    const lastName = pageNames[pageNames.length - 1];
+    const match = lastName.match(/^(-?\d+)/);
+    if (!match) return pageNumberOffset;
+    return parseInt(match[1], 10);
+};
+
+/**
  * Finds the next page in a sequence of pages based on the current page's nextPageId.
  *
  * @param currentPage The current page from which to find the next page.

--- a/apps/desktop/src/global/classes/Page.ts
+++ b/apps/desktop/src/global/classes/Page.ts
@@ -9,8 +9,10 @@ import {
     NewPageArgs,
 } from "@/db-functions";
 import { ModifyPagesRequest } from "@/hooks/queries/usePages";
+import { generatePageNames, getLastPageNumber } from "@openmarch/core";
 import { measureRangeString as _measureRangeString } from "./Page.utils";
 export const measureRangeString = _measureRangeString;
+export { generatePageNames, getLastPageNumber };
 interface Page {
     /** The id of the page in the database
      *
@@ -256,132 +258,6 @@ export function fromDatabasePages({
 
     return createdPages;
 }
-
-/**
- * Creates a list of page names based on the list of booleans that pages are subsets or not.
- *
- * E.g. [False, False, True, False, True, True, False] => ["1", "2", "2A", "3", "3A", "3B", "4"]
- *
- * NOTE - the first page will always evaluate to false no matter what is provided.
- *
- * @param pages boolean[] - A list to define if pages are subsets are not. Should align with the order of the pages.
- * @returns A list of page names in the order that the list of booleans was provided.
- */
-export const generatePageNames = (
-    isSubsetArr: boolean[],
-    pageNumberOffset: number = 0,
-) => {
-    const pageNames: string[] = [pageNumberOffset.toString()];
-    let curPageNumber = pageNumberOffset;
-    let curSubsetLetter = "";
-
-    /**
-     * Increments a letter to the next letter in the alphabet.
-     *
-     * @param letters The letters to increment.
-     * @returns A -> B, B -> C, ..., Z -> AA, AA -> AB, etc. Letters are always capitalized.
-     */
-    const incrementLetters = (letters: string) => {
-        let result = [];
-        let carry = true; // Start with the assumption that we need to increment the last character
-
-        const capitalizedLetters = letters.toUpperCase();
-
-        // Traverse from last to first character to handle the carry
-        for (let i = capitalizedLetters.length - 1; i >= 0; i--) {
-            let char = capitalizedLetters[i];
-            if (carry) {
-                if (char === "Z") {
-                    result.push("A");
-                } else {
-                    result.push(String.fromCharCode(char.charCodeAt(0) + 1));
-                    carry = false; // No carry needed if we haven't wrapped from 'Z' to 'A'
-                }
-            } else {
-                result.push(char); // If no carry, keep current character as is
-            }
-        }
-
-        // If the string was all 'Z's, we will have carry left over after processing all characters
-        if (carry) {
-            result.push("A"); // Append 'A' to handle cases like 'ZZ' -> 'AAA'
-        }
-
-        // Since we've constructed the result in reverse order, reverse it back and join into a string
-        return result.reverse().join("");
-    };
-
-    /**
-     * Get the next page name based on the current page name.
-     *
-     * @param pageNumber The number of the current page.
-     * @param subsetString The subset letter of the current page. If null, the page is not a subset.
-     * @param incrementSubset Whether it is the number or the subset letter that should be incremented.
-     *      Default is false, which increments the number. If true, increments the subset letter and not the number.
-     * @returns
-     */
-    const getNextPageName = ({
-        pageNumber,
-        subsetString,
-        incrementSubset = false,
-    }: {
-        pageNumber: number;
-        subsetString: string | null;
-        incrementSubset?: boolean;
-    }) => {
-        let newPageNumber = pageNumber;
-        let newSubsetString = subsetString || "";
-
-        if (incrementSubset) {
-            // If there is no subset, start with "A"
-            if (!subsetString || subsetString === "") newSubsetString = "A";
-            // Otherwise, increment the subset letter
-            else newSubsetString = incrementLetters(subsetString);
-        } else {
-            newPageNumber = pageNumber + 1;
-            newSubsetString = "";
-        }
-
-        return newPageNumber + newSubsetString;
-    };
-
-    // Loop through the pages and create the page names
-    // 1, 2, 2A, 3, 3A, 3B, 4, etc.
-    for (let i = 1; i < isSubsetArr.length; i++) {
-        const pageName = getNextPageName({
-            pageNumber: curPageNumber,
-            subsetString: isSubsetArr[i] ? curSubsetLetter : null,
-            incrementSubset: isSubsetArr[i],
-        });
-        pageNames.push(pageName);
-        if (isSubsetArr[i]) {
-            curSubsetLetter = incrementLetters(curSubsetLetter);
-        } else {
-            curPageNumber++;
-            curSubsetLetter = "";
-        }
-    }
-    return pageNames;
-};
-
-/**
- * Returns the numeric part of the last page name for an ordered subset list.
- *
- * This is the last named page number (e.g. 3 from "3" or "3B"), not the page count.
- * Empty input returns `pageNumberOffset`.
- */
-export const getLastPageNumber = (
-    isSubsetArr: boolean[],
-    pageNumberOffset: number = 0,
-): number => {
-    if (isSubsetArr.length === 0) return pageNumberOffset;
-
-    const pageNames = generatePageNames(isSubsetArr, pageNumberOffset);
-    const lastName = pageNames[pageNames.length - 1];
-    const match = lastName.match(/^(-?\d+)/);
-    if (!match) return pageNumberOffset;
-    return parseInt(match[1], 10);
-};
 
 /**
  * Finds the next page in a sequence of pages based on the current page's nextPageId.

--- a/apps/desktop/src/global/classes/Page.utils.ts
+++ b/apps/desktop/src/global/classes/Page.utils.ts
@@ -47,3 +47,5 @@ export const measureRangeString = (
         return "N/A";
     }
 };
+
+export { generatePageNames, getLastPageNumber } from "@openmarch/core";

--- a/apps/desktop/src/global/classes/__test__/Page.test.ts
+++ b/apps/desktop/src/global/classes/__test__/Page.test.ts
@@ -1,6 +1,7 @@
 import Page, {
     fromDatabasePages,
     generatePageNames,
+    getLastPageNumber,
     measureRangeString,
     yankOrPushPagesAfterIndex,
 } from "../Page";
@@ -315,6 +316,45 @@ describe("Page", () => {
         it("should handle zero offset explicitly", () => {
             const result = generatePageNames([false, false, true, false], 0);
             expect(result).toEqual(["0", "1", "1A", "2"]);
+        });
+    });
+
+    describe("getLastPageNumber", () => {
+        it("returns pageNumberOffset when input is empty", () => {
+            expect(getLastPageNumber([])).toBe(0);
+            expect(getLastPageNumber([], 5)).toBe(5);
+        });
+
+        it("returns the last named page number for sequential pages", () => {
+            expect(getLastPageNumber([false, false, false, false])).toBe(3);
+        });
+
+        it("returns the last named page number when subsets are present", () => {
+            expect(
+                getLastPageNumber([
+                    false,
+                    false,
+                    true,
+                    false,
+                    true,
+                    true,
+                    false,
+                ]),
+            ).toBe(3);
+        });
+
+        it("returns the last named page number with a source offset", () => {
+            expect(
+                getLastPageNumber(
+                    [false, false, true, false, true, true, false],
+                    3,
+                ),
+            ).toBe(6);
+        });
+
+        it("returns the number when the last page is a subset", () => {
+            expect(getLastPageNumber([false, false, true, true])).toBe(1);
+            expect(getLastPageNumber([false, false, true, true], 10)).toBe(11);
         });
     });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@
 export * from "./field";
 export * from "./shapes";
 export * from "./path-utility";
+export * from "./page";
 
 // Future core features can be added here:
 // export * from "./marching";

--- a/packages/core/src/page/PageNaming.ts
+++ b/packages/core/src/page/PageNaming.ts
@@ -1,0 +1,97 @@
+/**
+ * Creates page names based on an ordered list of subset flags.
+ *
+ * For example, [false, false, true, false, true, true, false] becomes
+ * ["1", "2", "2A", "3", "3A", "3B", "4"]. The first page always uses
+ * the page number offset, regardless of the first subset flag.
+ */
+export const generatePageNames = (
+    isSubsetArr: boolean[],
+    pageNumberOffset: number = 0,
+): string[] => {
+    const pageNames: string[] = [pageNumberOffset.toString()];
+    let curPageNumber = pageNumberOffset;
+    let curSubsetLetter = "";
+
+    const incrementLetters = (letters: string) => {
+        let result = [];
+        let carry = true;
+        const capitalizedLetters = letters.toUpperCase();
+
+        for (let i = capitalizedLetters.length - 1; i >= 0; i--) {
+            const char = capitalizedLetters[i]!;
+            if (carry) {
+                if (char === "Z") {
+                    result.push("A");
+                } else {
+                    result.push(String.fromCharCode(char.charCodeAt(0) + 1));
+                    carry = false;
+                }
+            } else {
+                result.push(char);
+            }
+        }
+
+        if (carry) result.push("A");
+        return result.reverse().join("");
+    };
+
+    const getNextPageName = ({
+        pageNumber,
+        subsetString,
+        incrementSubset = false,
+    }: {
+        pageNumber: number;
+        subsetString: string | null;
+        incrementSubset?: boolean;
+    }) => {
+        let newPageNumber = pageNumber;
+        let newSubsetString = subsetString || "";
+
+        if (incrementSubset) {
+            if (!subsetString || subsetString === "") newSubsetString = "A";
+            else newSubsetString = incrementLetters(subsetString);
+        } else {
+            newPageNumber = pageNumber + 1;
+            newSubsetString = "";
+        }
+
+        return newPageNumber + newSubsetString;
+    };
+
+    for (let i = 1; i < isSubsetArr.length; i++) {
+        const pageName = getNextPageName({
+            pageNumber: curPageNumber,
+            subsetString: isSubsetArr[i] ? curSubsetLetter : null,
+            incrementSubset: isSubsetArr[i],
+        });
+        pageNames.push(pageName);
+
+        if (isSubsetArr[i]) {
+            curSubsetLetter = incrementLetters(curSubsetLetter);
+        } else {
+            curPageNumber++;
+            curSubsetLetter = "";
+        }
+    }
+
+    return pageNames;
+};
+
+/**
+ * Returns the numeric part of the last page name for an ordered subset list.
+ *
+ * This is the last named page number, e.g. 3 from "3" or "3B", not the page count.
+ */
+export const getLastPageNumber = (
+    isSubsetArr: boolean[],
+    pageNumberOffset: number = 0,
+): number => {
+    if (isSubsetArr.length === 0) return pageNumberOffset;
+
+    const pageNames = generatePageNames(isSubsetArr, pageNumberOffset);
+    const lastName = pageNames[pageNames.length - 1]!;
+    const match = lastName.match(/^(-?\d+)/);
+    if (!match) return pageNumberOffset;
+    return parseInt(match[1]!, 10);
+};

--- a/packages/core/src/page/__test__/PageNaming.test.ts
+++ b/packages/core/src/page/__test__/PageNaming.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { generatePageNames, getLastPageNumber } from "../PageNaming";
+
+describe("generatePageNames", () => {
+    it("returns the offset for empty input", () => {
+        expect(generatePageNames([])).toEqual(["0"]);
+        expect(generatePageNames([], 5)).toEqual(["5"]);
+    });
+
+    it("generates sequential page names", () => {
+        expect(generatePageNames([false, false, false, false])).toEqual([
+            "0",
+            "1",
+            "2",
+            "3",
+        ]);
+    });
+
+    it("generates subset page names", () => {
+        expect(
+            generatePageNames([false, false, true, false, true, true]),
+        ).toEqual(["0", "1", "1A", "2", "2A", "2B"]);
+    });
+
+    it("generates multi-letter subset names", () => {
+        expect(
+            generatePageNames(Array.from({ length: 29 }, () => true)),
+        ).toEqual([
+            "0",
+            "0A",
+            "0B",
+            "0C",
+            "0D",
+            "0E",
+            "0F",
+            "0G",
+            "0H",
+            "0I",
+            "0J",
+            "0K",
+            "0L",
+            "0M",
+            "0N",
+            "0O",
+            "0P",
+            "0Q",
+            "0R",
+            "0S",
+            "0T",
+            "0U",
+            "0V",
+            "0W",
+            "0X",
+            "0Y",
+            "0Z",
+            "0AA",
+            "0AB",
+        ]);
+    });
+
+    it("applies page number offsets", () => {
+        expect(generatePageNames([false, false, true, false], 8)).toEqual([
+            "8",
+            "9",
+            "9A",
+            "10",
+        ]);
+    });
+
+    it("ignores the first subset flag", () => {
+        expect(generatePageNames([true, false, false], 20)).toEqual([
+            "20",
+            "21",
+            "22",
+        ]);
+    });
+});
+
+describe("getLastPageNumber", () => {
+    it("returns the offset for empty input", () => {
+        expect(getLastPageNumber([])).toBe(0);
+        expect(getLastPageNumber([], 5)).toBe(5);
+    });
+
+    it("returns the last numeric page number", () => {
+        expect(getLastPageNumber([false, false, false, false])).toBe(3);
+        expect(getLastPageNumber([false, false, true, true])).toBe(1);
+        expect(getLastPageNumber([false, false, true, true], 10)).toBe(11);
+    });
+});

--- a/packages/core/src/page/index.ts
+++ b/packages/core/src/page/index.ts
@@ -1,0 +1,1 @@
+export * from "./PageNaming";


### PR DESCRIPTION
- **initial commit**
- **import image and section appearance from previous dots file**
- **style start step**
- **Import designer and client**
- **parse from workspace settings func**
- **Import last page number**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “start” step to the new-show flow, with options to begin blank or import a previous `.dots` file.
  * Imports can restore performers, coordinates, field imagery, section appearances, tags and styling, marcher-tag links, and page-number settings.
  * Imported files now display a summary of the source and performer count.

* **Bug Fixes**
  * Preserved section-appearance visibility and label settings during setup.
  * Improved validation of workspace metadata and page-number settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->