### PR TITLE
Fix mobile export Sign In CTA clipped at large zoom

### DIFF
--- a/apps/desktop/src/components/mobile/MobileExportModal.tsx
+++ b/apps/desktop/src/components/mobile/MobileExportModal.tsx
@@ -205,14 +205,7 @@ export function MobileExportModalContents() {
                 </div>
             </header>
 
-            <div
-                className={clsx(
-                    "flex grow flex-col gap-16 pr-3",
-                    isSignedInView
-                        ? "overflow-y-auto"
-                        : "min-h-0 flex-1 overflow-hidden",
-                )}
-            >
+            <div className="flex min-h-0 flex-1 grow flex-col gap-16 overflow-y-auto pr-3">
                 <div
                     className={clsx(
                         "flex flex-col gap-12",
@@ -296,7 +289,7 @@ function SignedOutMobileExportContent() {
         " block h-200 w-auto shrink-0  drop-shadow-text-subtitle",
     );
     return (
-        <div className="text-body text-text-subtitle flex h-full min-h-0 flex-col gap-24 overflow-hidden text-center">
+        <div className="text-body text-text-subtitle flex h-full min-h-0 flex-col gap-24 overflow-y-auto text-center">
             <div className="flex shrink-0 grow flex-col items-center gap-16">
                 <div className="translate-x-[-32px]">
                     <img


### PR DESCRIPTION
## What
Users with large display scaling could not reach the Sign In button in the mobile export modal because the signed-out view clipped overflow.

## How
- Always allow vertical scroll on the mobile export content area
- Switch signed-out layout from `overflow-hidden` to `overflow-y-auto`