### PR TITLE
test: give each desktop e2e test an isolated Electron userData dir

### DIFF
--- a/apps/desktop/e2e/fixtures.mts
+++ b/apps/desktop/e2e/fixtures.mts
@@ -53,10 +53,12 @@ const PLAYWRIGHT_ENV = {
 /**
  * Per-test Electron userData directory.
  *
- * Without this every test shares the installed app's real userData directory,
- * so persisted settings (databasePath, theme, language, defaultFilesDirectory)
- * leak between tests and onto the machine running the suite. Tests then pass or
- * fail based on what an earlier test happened to write.
+ * Without this every test shares one userData directory on the machine running
+ * the suite: the generic `Electron` one, since the unpackaged binary does not
+ * pick up `productName` (so the installed OpenMarch app's own settings are not
+ * involved). Persisted settings (databasePath, theme, language,
+ * defaultFilesDirectory) leak between tests and survive between runs, so tests
+ * pass or fail based on what an earlier test happened to write.
  */
 const getUserDataDir = (testInfo: { outputDir: string }) =>
     path.resolve(testInfo.outputDir, "user-data");

--- a/apps/desktop/e2e/fixtures.mts
+++ b/apps/desktop/e2e/fixtures.mts
@@ -50,14 +50,31 @@ const PLAYWRIGHT_ENV = {
     DEBUG: "pw:browser",
 };
 
+/**
+ * Per-test Electron userData directory.
+ *
+ * Without this every test shares the installed app's real userData directory,
+ * so persisted settings (databasePath, theme, language, defaultFilesDirectory)
+ * leak between tests and onto the machine running the suite. Tests then pass or
+ * fail based on what an earlier test happened to write.
+ */
+const getUserDataDir = (testInfo: { outputDir: string }) =>
+    path.resolve(testInfo.outputDir, "user-data");
+
 const launchElectron = (options: {
     args: string[];
     env?: typeof PLAYWRIGHT_ENV;
-}) =>
-    electron.launch({
+    testInfo: { outputDir: string };
+}) => {
+    const { testInfo, args, ...rest } = options;
+    const userDataDir = getUserDataDir(testInfo);
+    fs.ensureDirSync(userDataDir);
+    return electron.launch({
         executablePath: electronExecutable,
-        ...options,
+        args: [...args, `--user-data-dir=${userDataDir}`],
+        ...rest,
     });
+};
 
 const getTempDotsPath = (testInfo: { outputDir: string }) => {
     return path.resolve(testInfo.outputDir, "temp.dots");
@@ -165,6 +182,7 @@ export const test = base.extend<MyFixtures>({
                     "--disable-audio-input",
                 ],
                 env: PLAYWRIGHT_ENV,
+                testInfo,
             });
 
             // Capture main process logs (optional, but good for debugging)
@@ -185,7 +203,7 @@ export const test = base.extend<MyFixtures>({
             }
         }
     },
-    electronAppEmpty: async ({}, use) => {
+    electronAppEmpty: async ({}, use, testInfo) => {
         let browser: ElectronApplication | undefined;
         try {
             browser = await launchElectron({
@@ -197,6 +215,7 @@ export const test = base.extend<MyFixtures>({
                     "--disable-audio-input",
                 ],
                 env: PLAYWRIGHT_ENV,
+                testInfo,
             });
 
             // Capture main process logs (optional, but good for debugging)
@@ -251,6 +270,7 @@ export const test = base.extend<MyFixtures>({
                     ...PLAYWRIGHT_ENV,
                     PLAYWRIGHT_NEW_FILE_PATH: newFilePath,
                 },
+                testInfo,
             });
 
             // Capture main process logs

--- a/apps/desktop/e2e/tests/new-show-wizard.spec.mts
+++ b/apps/desktop/e2e/tests/new-show-wizard.spec.mts
@@ -116,8 +116,12 @@ test("Refresh during wizard discards draft and returns to launch page", async ({
 
     await page.reload();
 
+    // Anchor on the launch page's New File button rather than the "Recent
+    // Files" heading: that heading only renders when recent files exist, so
+    // asserting on it only passed because earlier tests had populated the
+    // shared recent-files list.
     await expect(
-        page.getByRole("heading", { name: "Recent Files", level: 2 }),
+        page.getByRole("button", { name: "New File" }),
     ).toBeVisible();
     await expect(page.getByText("Timeline")).not.toBeVisible();
     await expect(dialog).not.toBeVisible();

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -310,12 +310,9 @@ function getPlaywrightDefaultDocumentsPath(): string | undefined {
 
 /**
  * Persist the parent directory of a newly created file as the default files
- * directory, honoring write-once semantics. No-op during Playwright sessions so
- * e2e runs never write into the shared app store (which would leak the first
- * test's output directory into every later test).
+ * directory, honoring write-once semantics.
  */
 function persistDefaultFilesDirectory(filePath: string) {
-    if (process.env.PLAYWRIGHT_SESSION) return;
     const dirToPersist = computeDefaultDirectoryToPersist(
         store.get("defaultFilesDirectory") as string | undefined,
         filePath,


### PR DESCRIPTION
> Stacked on #987. Base will auto-retarget to `main` once that merges — review only the 3-file diff here.

## Problem

Every desktop e2e test launches Electron against the **same** `userData` directory, so everything `electron-store` persists — `databasePath`, `theme`, `language`, and now `defaultFilesDirectory` — leaks from one test into the next. Tests can pass or fail based on what an earlier test happened to write, and the resulting failures surface nowhere near their cause.

This is not hypothetical. It is exactly what broke #987: the new-show wizard began preferring the persisted `defaultFilesDirectory`, the first test to create a show pinned its own `testInfo.outputDir` there (write-once), and every later test then saved into that first test's directory. Three tests failed with `expected true, received false` about a file existing — a message that points nowhere near a shared settings file.

The store also **survives between runs** on a developer's machine. `settings.spec.mts` cycles the app through Spanish, Portuguese, and Japanese; if it dies partway, the store keeps `"es"` and the *next* run starts in Spanish, failing every test that asserts on English text. CI never sees this, because CI runners are always fresh. Green in CI, red locally, no cause visible in the diff.

(For the record: this writes to the generic `Electron` userData directory, not the installed OpenMarch app's — the unpackaged binary doesn't pick up `productName`. Your personal app settings are not affected.)

## Change

Pass `--user-data-dir` per test, rooted at `testInfo.outputDir`. Verified: 37 per-test directories created, and the shared `Electron/config.json` is no longer modified by a suite run.

Also drops the `PLAYWRIGHT_SESSION` guard in `persistDefaultFilesDirectory` that #987 added — isolation makes it dead code. Net effect is *less* test-aware branching in the shipped main process.

## What this immediately found

`new-show-wizard.spec.mts` → "Refresh during wizard discards draft and returns to launch page" failed as soon as tests stopped sharing state.

It confirmed the user was back on the launch page by asserting the **"Recent Files"** heading was visible. But `FilesContent.tsx:100` renders that heading only when `recentFiles.length !== 0`; with an empty list you get `<WelcomeContent />` and no heading.

So that assertion only ever passed because **earlier tests had populated the shared recent-files list**. Every run was exercising the returning-user launch page and calling it the launch page — **the first-run view, which every new user sees, had no coverage at all.**

Fixed by anchoring on the `New File` button, which is present in both the welcome and recent-files states, and is already the locator this same test uses to open the wizard.

To be clear about scope: this exposed a **coverage gap, not an app bug**. The launch page renders correctly for new and returning users alike. What was broken was our ability to know that.

## Verification

- Full desktop e2e suite: **37 passed, 2 skipped, 0 failed** (2.6m, local macOS)
- 37 per-test `user-data` directories created, one per test
- Shared `Electron/config.json` mtime unchanged across two isolated runs, after being written by every prior non-isolated run

🤖 Generated with [Claude Code](https://claude.com/claude-code)