### PR TITLE
fix: typing a quantity on the New show Performers step doesn't register

### DIFF
--- a/apps/desktop/src/components/marcher/MarcherForm.tsx
+++ b/apps/desktop/src/components/marcher/MarcherForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Marcher from "@/global/classes/Marcher";
 import {
     getSectionObjectByName,
@@ -44,6 +44,7 @@ const defaultSection = (t: (key: string) => string) =>
 
 const defaultDrillPrefix = "-";
 const defaultDrillOrder = 1;
+const defaultQuantity = 1;
 
 // eslint-disable-next-line react/prop-types, max-lines-per-function
 const MarcherForm: React.FC<MarcherFormProps> = ({
@@ -55,7 +56,18 @@ const MarcherForm: React.FC<MarcherFormProps> = ({
     wizardMode = false,
     marcherIdToEdit,
 }) => {
-    const [quantity, setQuantity] = useState<number>(1);
+    // Stored as the raw string so the field can be emptied while typing. Keep
+    // this input controlled: resetForm() calls formRef.current.reset(), which
+    // changes the DOM value without notifying React. An uncontrolled input
+    // leaves React's internal value tracker stale, and it then suppresses the
+    // change event when the user retypes the pre-reset value. See issue #1004.
+    const [quantityInput, setQuantityInput] = useState<string>(
+        String(defaultQuantity),
+    );
+    const quantity = useMemo(() => {
+        const parsed = parseInt(quantityInput, 10);
+        return Number.isNaN(parsed) || parsed < 1 ? defaultQuantity : parsed;
+    }, [quantityInput]);
     const [section, setSection] = useState<string>();
     const [name, setName] = useState<string>("");
     const [year, setYear] = useState<string>("");
@@ -98,7 +110,7 @@ const MarcherForm: React.FC<MarcherFormProps> = ({
     }, [t]);
 
     const resetForm = (preserveSection = false) => {
-        setQuantity(1);
+        setQuantityInput(String(defaultQuantity));
         if (!preserveSection) {
             setSection(defaultSection(t));
         }
@@ -219,8 +231,7 @@ const MarcherForm: React.FC<MarcherFormProps> = ({
     const handleQuantityChange = (
         event: React.ChangeEvent<HTMLInputElement>,
     ) => {
-        if (event.target.value === "") setQuantity(1);
-        else setQuantity(parseInt(event.target.value));
+        setQuantityInput(event.target.value);
     };
 
     const resetDrillOrder = useCallback(() => {
@@ -313,7 +324,7 @@ const MarcherForm: React.FC<MarcherFormProps> = ({
                     <FormField label={t("marchers.quantity")}>
                         <Input
                             type="number"
-                            defaultValue={1}
+                            value={quantityInput}
                             onChange={handleQuantityChange}
                             step={1}
                             min={1}

--- a/apps/desktop/src/components/marcher/__test__/MarcherForm.test.tsx
+++ b/apps/desktop/src/components/marcher/__test__/MarcherForm.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TolgeeProvider } from "@tolgee/react";
+import tolgee from "@/global/singletons/Tolgee";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import MarcherForm from "../MarcherForm";
+import type { NewMarcherArgs } from "@/db-functions";
+
+const Providers = ({ children }: { children: React.ReactNode }) => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return (
+        <QueryClientProvider client={queryClient}>
+            <TolgeeProvider tolgee={tolgee} fallback="Loading...">
+                {children}
+            </TolgeeProvider>
+        </QueryClientProvider>
+    );
+};
+
+const renderForm = (onMarchersCreate: (m: NewMarcherArgs[]) => void) =>
+    render(
+        <MarcherForm
+            hideInfoNote
+            skipSidebarContent
+            onMarchersCreate={onMarchersCreate}
+            existingMarchers={[]}
+            wizardMode
+        />,
+        { wrapper: Providers },
+    );
+
+const quantityInput = () =>
+    screen.getByLabelText(/quantity/i) as HTMLInputElement;
+const createButton = () => screen.getByRole("button", { name: /create/i });
+
+describe("MarcherForm quantity", () => {
+    beforeAll(async () => {
+        await tolgee.run();
+    });
+    afterEach(() => cleanup());
+
+    it("creates the typed quantity of marchers", async () => {
+        const user = userEvent.setup();
+        const onMarchersCreate = vi.fn<(m: NewMarcherArgs[]) => void>();
+        renderForm(onMarchersCreate);
+
+        await user.tripleClick(quantityInput());
+        await user.keyboard("12");
+
+        expect(createButton()).toHaveTextContent("Create 12 Other Marchers");
+
+        await user.click(createButton());
+
+        expect(onMarchersCreate.mock.calls[0][0]).toHaveLength(12);
+    });
+
+    /**
+     * Regression test for issue #1004.
+     *
+     * resetForm() calls formRef.current.reset(), which changes the input's DOM
+     * value without going through React. If the quantity input is uncontrolled,
+     * React's internal value tracker keeps the pre-reset value, and it then
+     * suppresses the change event when the user retypes that same value — the
+     * button label stays singular and only one marcher gets created.
+     */
+    it("creates the typed quantity again when the same number is reused after a reset", async () => {
+        const user = userEvent.setup();
+        const onMarchersCreate = vi.fn<(m: NewMarcherArgs[]) => void>();
+        renderForm(onMarchersCreate);
+
+        // First batch of 4 — this submit resets the form.
+        await user.tripleClick(quantityInput());
+        await user.keyboard("4");
+        await user.click(createButton());
+        expect(onMarchersCreate.mock.calls[0][0]).toHaveLength(4);
+
+        // The form resets back to 1 after a successful create.
+        expect(quantityInput().value).toBe("1");
+
+        // Second batch, retyping the SAME quantity as before.
+        await user.tripleClick(quantityInput());
+        await user.keyboard("4");
+
+        expect(createButton()).toHaveTextContent("Create 4 Other Marchers");
+
+        await user.click(createButton());
+
+        expect(onMarchersCreate.mock.calls[1][0]).toHaveLength(4);
+    });
+
+    it("can be cleared while typing and treats an empty field as 1", async () => {
+        const user = userEvent.setup();
+        const onMarchersCreate = vi.fn<(m: NewMarcherArgs[]) => void>();
+        renderForm(onMarchersCreate);
+
+        await user.clear(quantityInput());
+
+        expect(quantityInput().value).toBe("");
+        expect(createButton()).toHaveTextContent("Create Other Marcher");
+
+        // Typing after clearing starts fresh rather than appending to a "1".
+        await user.keyboard("25");
+        expect(quantityInput().value).toBe("25");
+        expect(createButton()).toHaveTextContent("Create 25 Other Marchers");
+    });
+});


### PR DESCRIPTION
Fixes #1004

## Symptom

On the New show wizard's Performers step, typing a number into Quantity leaves the button reading "Create Other Marcher" (singular, no number), and pressing it creates a single marcher. Clicking the stepper arrows works.

The reporter's screenshot shows the tell: the field reads `4` while the button is still in its singular form — the DOM and React state disagree.

## Root cause

React keeps a `_valueTracker` on each input and uses it to **deduplicate** change events: if an input event carries a value equal to the tracked one, `onChange` never fires.

`resetForm()` calls `formRef.current.reset()` after every successful create. Native `form.reset()` rewrites the DOM value **without going through React's property setter**, so the tracker keeps the pre-reset value (`"4"`) while the DOM shows `1`.

When the user retypes that same quantity, React compares `"4"` against its stale tracked `"4"`, concludes nothing changed, and suppresses the event. `quantity` stays `1`.

The stepper appears to "fix" it only because it produces a *different* value (`1` → `2`), so the dedupe never triggers.

This is why it takes **reusing the same number twice in a row** to hit — which matches the screenshot, where batches had already been added.

## Fix

`quantity` was the only uncontrolled input in this form; every sibling (`name`, `year`, `drillPrefix`, `drillOrder`, `notes`) is already controlled. Made it match:

- Store the raw string so the field can still be emptied mid-typing, and derive the number with `useMemo`.
- Empty/invalid input resolves to `1`, preserving previous behavior.
- Added a comment at the declaration explaining why it must stay controlled, so it doesn't regress to `defaultValue`.

`MarcherForm` is shared, so this fixes **both** the wizard's Performers step and the in-app Add Marchers modal (`MarchersModal.tsx:102`). The issue only reports the wizard; the modal had the identical defect.

## Checked everywhere else in the flow

Four sites call native `form.reset()`:

| Site | Verdict |
|---|---|
| `MarcherForm.tsx:127` | **Vulnerable** — the only uncontrolled input. Fixed. |
| `MarcherEditor.tsx:583,605` | Safe — all inputs controlled, no `defaultValue` |
| `PageEditor.tsx:27` | Safe — no text inputs, only a controlled `Switch` |
| `AudioFileSettings.tsx:370` | Not a form — react-query `mutation.reset()` |

I also probed the other out-of-band write pattern, direct `.value =` assignment (6 sites). Those are **safe**: React installs a property descriptor on the node, so direct assignment keeps the tracker in sync. Verified with a harness comparing both mechanisms — `form.reset()` suppressed the subsequent change event, direct assignment did not.

**The rule for future work:** `form.reset()` is the hazard, and only when combined with an uncontrolled input. The 8 other files using `defaultValue` are fine because none of them call `form.reset()`.

## Tests

Three tests added in `MarcherForm.test.tsx`, including a regression test pinning the exact user sequence from the issue. Verified it **fails on unfixed code** and passes with the fix.

- Full desktop unit suite: **1180 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)