### PR TITLE
feat: searchable Select tab chips with recent items

### DIFF
--- a/apps/desktop/i18n/en.json
+++ b/apps/desktop/i18n/en.json
@@ -1140,8 +1140,11 @@
         },
         "select": {
             "noDrillPrefixesToSelect": "No drill prefixes to select found",
+            "noResultsFound": "No results found",
             "noSectionsToSelect": "No sections to select found",
             "noTagsToSelect": "No tags to select found",
+            "recent": "Recent",
+            "searchPlaceholder": "Search...",
             "selectBy": {
                 "drillPrefix": "Drill Prefix",
                 "family": "Family",

--- a/apps/desktop/src/components/toolbar/tabs/ChipSelector.tsx
+++ b/apps/desktop/src/components/toolbar/tabs/ChipSelector.tsx
@@ -74,6 +74,11 @@ export default function ChipSelector<T>({
                 : items.slice(0, maxVisible),
         [items, recentIds, getId, maxVisible, recentCategory],
     );
+    const hasResolvedRecents = useMemo(() => {
+        if (!recentCategory || recentIds.length === 0) return false;
+        const ids = new Set(items.map((item) => String(getId(item))));
+        return recentIds.some((id) => ids.has(id));
+    }, [recentCategory, recentIds, items, getId]);
     const showSearch = items.length > visibleItems.length;
 
     const filteredItems = useMemo(() => {
@@ -292,7 +297,7 @@ export default function ChipSelector<T>({
                 </>
             )}
             {visibleItems.length === 0 && emptyMessage}
-            {visibleItems.length > 0 && (
+            {visibleItems.length > 0 && hasResolvedRecents && (
                 <span className="text-text-subtitle">
                     <T keyName="toolbar.select.recent" />
                     {" -"}

--- a/apps/desktop/src/components/toolbar/tabs/ChipSelector.tsx
+++ b/apps/desktop/src/components/toolbar/tabs/ChipSelector.tsx
@@ -29,8 +29,8 @@ export type ChipSelectorProps<T> = {
     getLabel: (item: T) => React.ReactNode;
     /** Plain-string label used for case-insensitive substring filtering */
     getSearchText: (item: T) => string;
-    /** Fired from a chip click, a dropdown Enter, or a dropdown option click */
-    onSelect: (item: T, options: { shiftKey: boolean }) => void;
+    /** Fired from a chip click, a dropdown Enter, or a dropdown option click. Return false to skip persisting recents. */
+    onSelect: (item: T, options: { shiftKey: boolean }) => boolean | void;
     /** Rendered instead of the chip row when items.length === 0 */
     emptyMessage?: React.ReactNode;
     /** Accessible name applied to the search input and its listbox */
@@ -74,7 +74,7 @@ export default function ChipSelector<T>({
                 : items.slice(0, maxVisible),
         [items, recentIds, getId, maxVisible, recentCategory],
     );
-    const showSearch = items.length > maxVisible;
+    const showSearch = items.length > visibleItems.length;
 
     const filteredItems = useMemo(() => {
         const q = query.trim().toLowerCase();
@@ -139,16 +139,18 @@ export default function ChipSelector<T>({
     }, [open, activeIndex]);
 
     const selectItem = (item: T, shiftKey: boolean) => {
-        if (recentCategory) {
-            const next = pushRecentId(
-                recentIds,
-                String(getId(item)),
-                maxVisible,
+        const result = onSelect(item, { shiftKey });
+        if (recentCategory && result !== false) {
+            const id = String(getId(item));
+            const alreadyVisible = visibleItems.some(
+                (visible) => String(getId(visible)) === id,
             );
-            setRecentIds(next);
-            writeRecentIds(recentCategory, next);
+            if (!alreadyVisible) {
+                const next = pushRecentId(recentIds, id, maxVisible);
+                setRecentIds(next);
+                writeRecentIds(recentCategory, next);
+            }
         }
-        onSelect(item, { shiftKey });
         setQuery("");
         setHighlightedIndex(0);
         setOpen(false);

--- a/apps/desktop/src/components/toolbar/tabs/ChipSelector.tsx
+++ b/apps/desktop/src/components/toolbar/tabs/ChipSelector.tsx
@@ -1,0 +1,315 @@
+import { Input, ListItem } from "@openmarch/ui";
+import { T, useTranslate } from "@tolgee/react";
+import React, {
+    useId,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
+import { createPortal } from "react-dom";
+import {
+    DEFAULT_MAX_VISIBLE_CHIPS,
+    pushRecentId,
+    readRecentIds,
+    resolveRecentItems,
+    writeRecentIds,
+} from "./chipSelectorRecents";
+
+export const Separator = () => {
+    return <span className="text-text-subtitle opacity-50">|</span>;
+};
+
+export type ChipSelectorProps<T> = {
+    /** Full underlying data set, already sorted by the caller in display order */
+    items: T[];
+    /** Stable identity for keys / aria-activedescendant ids */
+    getId: (item: T) => string | number;
+    /** Rendered chip / option label - may be JSX (e.g. <T keyName=.../>) */
+    getLabel: (item: T) => React.ReactNode;
+    /** Plain-string label used for case-insensitive substring filtering */
+    getSearchText: (item: T) => string;
+    /** Fired from a chip click, a dropdown Enter, or a dropdown option click */
+    onSelect: (item: T, options: { shiftKey: boolean }) => void;
+    /** Rendered instead of the chip row when items.length === 0 */
+    emptyMessage?: React.ReactNode;
+    /** Accessible name applied to the search input and its listbox */
+    ariaLabel: string;
+    /** Max chips shown before the search box appears. Default 6 */
+    maxVisible?: number;
+    /** Override for the "no results" row; defaults to toolbar.select.noResultsFound */
+    noResultsMessage?: React.ReactNode;
+    /** When set, the chip row shows a LIFO recent list persisted under this category */
+    recentCategory?: string;
+};
+
+export default function ChipSelector<T>({
+    items,
+    getId,
+    getLabel,
+    getSearchText,
+    onSelect,
+    emptyMessage,
+    ariaLabel,
+    maxVisible = DEFAULT_MAX_VISIBLE_CHIPS,
+    noResultsMessage,
+    recentCategory,
+}: ChipSelectorProps<T>) {
+    const { t } = useTranslate();
+    const [query, setQuery] = useState("");
+    const [open, setOpen] = useState(false);
+    const [highlightedIndex, setHighlightedIndex] = useState(0);
+    const [panelStyle, setPanelStyle] = useState<React.CSSProperties>({});
+    const [recentIds, setRecentIds] = useState<string[]>(() =>
+        recentCategory ? readRecentIds(recentCategory) : [],
+    );
+    const inputRef = useRef<HTMLInputElement>(null);
+    const listboxRef = useRef<HTMLDivElement>(null);
+    const listboxId = useId();
+
+    const visibleItems = useMemo(
+        () =>
+            recentCategory
+                ? resolveRecentItems(items, recentIds, getId, maxVisible)
+                : items.slice(0, maxVisible),
+        [items, recentIds, getId, maxVisible, recentCategory],
+    );
+    const showSearch = items.length > maxVisible;
+
+    const filteredItems = useMemo(() => {
+        const q = query.trim().toLowerCase();
+        if (q.length === 0) return items;
+        return items.filter((item) =>
+            getSearchText(item).toLowerCase().includes(q),
+        );
+    }, [items, query, getSearchText]);
+
+    const activeIndex =
+        filteredItems.length === 0
+            ? -1
+            : Math.min(highlightedIndex, filteredItems.length - 1);
+
+    // The toolbar sits inside an `overflow-hidden` ancestor (see Toolbar.tsx),
+    // so the dropdown is portaled to <body> and positioned from the input's
+    // viewport rect rather than relying on normal absolute-positioning flow.
+    useLayoutEffect(() => {
+        if (!open) return;
+
+        const updatePosition = () => {
+            const rect = inputRef.current?.getBoundingClientRect();
+            if (!rect) return;
+            setPanelStyle({
+                position: "fixed",
+                top: rect.bottom + 4,
+                left: rect.left,
+            });
+        };
+
+        updatePosition();
+        window.addEventListener("resize", updatePosition);
+        window.addEventListener("scroll", updatePosition, true);
+        return () => {
+            window.removeEventListener("resize", updatePosition);
+            window.removeEventListener("scroll", updatePosition, true);
+        };
+    }, [open]);
+
+    // Keep the highlighted option in view when arrowing through a list taller
+    // than the dropdown. Adjust the listbox scrollTop directly so the portaled
+    // fixed panel does not also scroll the page via scrollIntoView.
+    useLayoutEffect(() => {
+        if (!open || activeIndex < 0) return;
+        const listbox = listboxRef.current;
+        const option = listbox?.children[activeIndex] as
+            | HTMLElement
+            | undefined;
+        if (!listbox || !option) return;
+
+        const listboxRect = listbox.getBoundingClientRect();
+        const optionRect = option.getBoundingClientRect();
+        const styles = getComputedStyle(listbox);
+        const visibleTop = listboxRect.top + parseFloat(styles.paddingTop);
+        const visibleBottom =
+            listboxRect.bottom - parseFloat(styles.paddingBottom);
+        if (optionRect.bottom > visibleBottom) {
+            listbox.scrollTop += optionRect.bottom - visibleBottom;
+        } else if (optionRect.top < visibleTop) {
+            listbox.scrollTop -= visibleTop - optionRect.top;
+        }
+    }, [open, activeIndex]);
+
+    const selectItem = (item: T, shiftKey: boolean) => {
+        if (recentCategory) {
+            const next = pushRecentId(
+                recentIds,
+                String(getId(item)),
+                maxVisible,
+            );
+            setRecentIds(next);
+            writeRecentIds(recentCategory, next);
+        }
+        onSelect(item, { shiftKey });
+        setQuery("");
+        setHighlightedIndex(0);
+        setOpen(false);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        switch (e.key) {
+            case "ArrowDown":
+            case "ArrowUp": {
+                e.preventDefault();
+                if (!open) {
+                    setOpen(true);
+                    return;
+                }
+                if (filteredItems.length === 0) return;
+                setHighlightedIndex((prev) => {
+                    const base = prev < 0 ? 0 : prev;
+                    const delta = e.key === "ArrowDown" ? 1 : -1;
+                    return (
+                        (base + delta + filteredItems.length) %
+                        filteredItems.length
+                    );
+                });
+                return;
+            }
+            case "Enter": {
+                e.preventDefault();
+                if (!open || activeIndex < 0) return;
+                selectItem(filteredItems[activeIndex], e.shiftKey);
+                inputRef.current?.blur();
+                return;
+            }
+            case "Escape": {
+                e.preventDefault();
+                setOpen(false);
+                setQuery("");
+                inputRef.current?.blur();
+                return;
+            }
+            default:
+                return;
+        }
+    };
+
+    const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setQuery(e.target.value);
+        setHighlightedIndex(0);
+        if (!open) setOpen(true);
+    };
+
+    const handleInputBlur = () => {
+        // Option rows are selected via onMouseDown+preventDefault (below), so
+        // the input never actually blurs when clicking one - only a genuine
+        // click/focus elsewhere reaches here.
+        setOpen(false);
+    };
+
+    const handleOptionMouseDown = (e: React.MouseEvent, item: T) => {
+        e.preventDefault();
+        selectItem(item, e.shiftKey);
+        inputRef.current?.blur();
+    };
+
+    return (
+        <div className="flex items-center gap-8">
+            {showSearch && (
+                <>
+                    <Input
+                        ref={inputRef}
+                        compact
+                        role="combobox"
+                        aria-expanded={open}
+                        aria-controls={listboxId}
+                        aria-autocomplete="list"
+                        aria-activedescendant={
+                            activeIndex >= 0
+                                ? `${listboxId}-option-${getId(
+                                      filteredItems[activeIndex],
+                                  )}`
+                                : undefined
+                        }
+                        aria-label={ariaLabel}
+                        className="w-[8.5rem]"
+                        placeholder={t("toolbar.select.searchPlaceholder")}
+                        value={query}
+                        onFocus={() => setOpen(true)}
+                        onChange={handleQueryChange}
+                        onKeyDown={handleKeyDown}
+                        onBlur={handleInputBlur}
+                    />
+                    {open &&
+                        createPortal(
+                            <div
+                                ref={listboxRef}
+                                id={listboxId}
+                                role="listbox"
+                                aria-label={ariaLabel}
+                                style={panelStyle}
+                                className="bg-modal border-stroke rounded-6 shadow-modal backdrop-blur-32 z-[9999] flex max-h-[280px] w-[14rem] flex-col gap-2 overflow-y-auto border p-4"
+                            >
+                                {filteredItems.length === 0 ? (
+                                    <div className="text-text-subtitle text-body px-8 py-4">
+                                        {noResultsMessage ?? (
+                                            <T keyName="toolbar.select.noResultsFound" />
+                                        )}
+                                    </div>
+                                ) : (
+                                    filteredItems.map((item, index) => (
+                                        <div
+                                            key={getId(item)}
+                                            id={`${listboxId}-option-${getId(item)}`}
+                                            role="option"
+                                            aria-selected={
+                                                index === activeIndex
+                                            }
+                                            onMouseDown={(e) =>
+                                                handleOptionMouseDown(e, item)
+                                            }
+                                            onMouseEnter={() =>
+                                                setHighlightedIndex(index)
+                                            }
+                                        >
+                                            <ListItem
+                                                selected={index === activeIndex}
+                                                className={
+                                                    index === activeIndex
+                                                        ? undefined
+                                                        : "border border-transparent"
+                                                }
+                                            >
+                                                {getLabel(item)}
+                                            </ListItem>
+                                        </div>
+                                    ))
+                                )}
+                            </div>,
+                            document.body,
+                        )}
+                </>
+            )}
+            {visibleItems.length === 0 && emptyMessage}
+            {visibleItems.length > 0 && (
+                <span className="text-text-subtitle">
+                    <T keyName="toolbar.select.recent" />
+                    {" -"}
+                </span>
+            )}
+            {visibleItems.map((item, index) => (
+                <React.Fragment key={getId(item)}>
+                    <button
+                        className="hover:text-accent flex items-center gap-8 outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:opacity-50"
+                        onClick={(e) => {
+                            e.preventDefault();
+                            selectItem(item, e.shiftKey);
+                        }}
+                    >
+                        {getLabel(item)}
+                    </button>
+                    {index < visibleItems.length - 1 && <Separator />}
+                </React.Fragment>
+            ))}
+        </div>
+    );
+}

--- a/apps/desktop/src/components/toolbar/tabs/SelectTab.tsx
+++ b/apps/desktop/src/components/toolbar/tabs/SelectTab.tsx
@@ -2,6 +2,7 @@ import Marcher from "@/global/classes/Marcher";
 import {
     FAMILIES,
     getSectionObjectByName,
+    getTranslatedSectionName,
     SectionFamily,
 } from "@/global/classes/Sections";
 import {
@@ -14,9 +15,10 @@ import ToolbarSection from "../ToolbarSection";
 import { useSelectedMarchers } from "@/context/SelectedMarchersContext";
 import { useCallback, useEffect, useState } from "react";
 import { CaretDownIcon } from "@phosphor-icons/react";
-import { T } from "@tolgee/react";
+import { T, useTranslate } from "@tolgee/react";
 import * as Popover from "@radix-ui/react-popover";
-import { getTagName } from "@/db-functions/tag";
+import { getTagName, type DatabaseTag } from "@/db-functions/tag";
+import ChipSelector from "./ChipSelector";
 
 export default function ViewTab() {
     return (
@@ -25,10 +27,6 @@ export default function ViewTab() {
         </div>
     );
 }
-
-const Separator = () => {
-    return <span className="text-text-subtitle opacity-50">|</span>;
-};
 
 const sectionsFromMarchers = (marchers: Pick<Marcher, "section">[]) => {
     const sectionStrings = new Set([
@@ -45,14 +43,13 @@ const useHandleSelect = ({ allMarchers }: { allMarchers: Marcher[] }) => {
     const { selectedMarchers, setSelectedMarchers } = useSelectedMarchers()!;
 
     const selectMarcherIds = useCallback(
-        (e: React.MouseEvent<HTMLButtonElement>, ids: number[]) => {
-            e.preventDefault();
+        (ids: number[], options?: { shiftKey?: boolean }) => {
             const newSelectedMarchers = allMarchers.filter((marcher) =>
                 ids.includes(marcher.id),
             );
 
             // if holding shift, add to selection
-            if (e.shiftKey) {
+            if (options?.shiftKey) {
                 const currentlySelectedIds = new Set(
                     selectedMarchers.map((marcher) => marcher.id),
                 );
@@ -122,48 +119,43 @@ function SelectByPopover({
 }
 
 function SectionSelector({ marchers }: { marchers: Marcher[] }) {
+    const { t } = useTranslate();
     const sections = sectionsFromMarchers(marchers ?? []);
     const { selectMarcherIds } = useHandleSelect({
         allMarchers: marchers ?? [],
     });
 
     const handleSelectBySection = useCallback(
-        (e: React.MouseEvent<HTMLButtonElement>, section: string) => {
-            e.preventDefault();
+        (
+            section: (typeof sections)[number],
+            options?: { shiftKey?: boolean },
+        ) => {
             const marcherIds = marchers
-                .filter((marcher) => marcher.section === section)
+                .filter((marcher) => marcher.section === section.name)
                 .map((marcher) => marcher.id);
-            selectMarcherIds(e, marcherIds);
+            selectMarcherIds(marcherIds, options);
         },
         [marchers, selectMarcherIds],
     );
 
     return (
         <ToolbarSection aria-label="Select sections">
-            <div className="flex gap-8">
-                {sections.length > 0 ? (
-                    sections.map((section, index) => (
-                        <div
-                            key={section.name}
-                            className="flex items-center gap-8"
-                        >
-                            <button
-                                className="hover:text-accent flex items-center gap-8 outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:opacity-50"
-                                onClick={(e) =>
-                                    handleSelectBySection(e, section.name)
-                                }
-                            >
-                                <T keyName={section.tName} />
-                            </button>
-                            {index < sections.length - 1 && <Separator />}
-                        </div>
-                    ))
-                ) : (
+            <ChipSelector
+                items={sections}
+                getId={(section) => section.name}
+                getLabel={(section) => <T keyName={section.tName} />}
+                getSearchText={(section) =>
+                    getTranslatedSectionName(section.name, t)
+                }
+                onSelect={handleSelectBySection}
+                emptyMessage={
                     <div>
                         <T keyName="toolbar.select.noSectionsToSelect" />
                     </div>
-                )}
-            </div>
+                }
+                ariaLabel="Select sections"
+                recentCategory="section"
+            />
         </ToolbarSection>
     );
 }
@@ -179,43 +171,41 @@ function TagSelector({ marchers }: { marchers: Marcher[] }) {
     });
 
     const handleSelectByTag = useCallback(
-        (e: React.MouseEvent<HTMLButtonElement>, tagId: number) => {
-            e.preventDefault();
+        (tag: DatabaseTag, options?: { shiftKey?: boolean }) => {
             if (!marcherIdsForTagsLoaded) {
                 console.error("Marcher IDs for tags not loaded");
                 return;
             }
-            const marcherIds = marcherIdsForTags.get(tagId);
+            const marcherIds = marcherIdsForTags.get(tag.id);
             if (marcherIds == null) {
-                console.error(`Marcher IDs for tag ${tagId} not found`);
+                console.error(`Marcher IDs for tag ${tag.id} not found`);
                 return;
             }
-            selectMarcherIds(e, marcherIds);
+            selectMarcherIds(marcherIds, options);
         },
         [marcherIdsForTags, marcherIdsForTagsLoaded, selectMarcherIds],
     );
 
     return (
-        <ToolbarSection aria-label="Select sections">
-            <div className="flex gap-8">
-                {tagsLoaded && tags?.length > 0 ? (
-                    tags.map((tag, index) => (
-                        <div key={tag.id} className="flex items-center gap-8">
-                            <button
-                                className="hover:text-accent flex items-center gap-8 outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:opacity-50"
-                                onClick={(e) => handleSelectByTag(e, tag.id)}
-                            >
-                                {getTagName({ tag_id: tag.id, name: tag.name })}
-                            </button>
-                            {index < tags.length - 1 && <Separator />}
-                        </div>
-                    ))
-                ) : (
+        <ToolbarSection aria-label="Select tags">
+            <ChipSelector
+                items={tagsLoaded ? (tags ?? []) : []}
+                getId={(tag) => tag.id}
+                getLabel={(tag) =>
+                    getTagName({ tag_id: tag.id, name: tag.name })
+                }
+                getSearchText={(tag) =>
+                    getTagName({ tag_id: tag.id, name: tag.name })
+                }
+                onSelect={handleSelectByTag}
+                emptyMessage={
                     <div>
                         <T keyName="toolbar.select.noTagsToSelect" />
                     </div>
-                )}
-            </div>
+                }
+                ariaLabel="Select tags"
+                recentCategory="tag"
+            />
         </ToolbarSection>
     );
 }
@@ -229,55 +219,44 @@ function DrillPrefixSelector({ marchers }: { marchers: Marcher[] }) {
     });
 
     const handleSelectByDrillPrefix = useCallback(
-        (e: React.MouseEvent<HTMLButtonElement>, drillPrefix: string) => {
-            e.preventDefault();
+        (drillPrefix: string, options?: { shiftKey?: boolean }) => {
             const marcherIds = marchers
                 .filter((marcher) => marcher.drill_prefix === drillPrefix)
                 .map((marcher) => marcher.id);
-            selectMarcherIds(e, marcherIds);
+            selectMarcherIds(marcherIds, options);
         },
         [marchers, selectMarcherIds],
     );
 
     return (
         <ToolbarSection aria-label="Select drill prefixes">
-            <div className="flex gap-8">
-                {drillPrefixes.length > 0 ? (
-                    drillPrefixes.map((drillPrefix, index) => (
-                        <div
-                            key={drillPrefix}
-                            className="flex items-center gap-8"
-                        >
-                            <button
-                                className="hover:text-accent flex items-center gap-8 outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:opacity-50"
-                                onClick={(e) =>
-                                    handleSelectByDrillPrefix(e, drillPrefix)
-                                }
-                            >
-                                {drillPrefix}
-                            </button>
-                            {index < drillPrefixes.length - 1 && <Separator />}
-                        </div>
-                    ))
-                ) : (
+            <ChipSelector
+                items={drillPrefixes}
+                getId={(drillPrefix) => drillPrefix}
+                getLabel={(drillPrefix) => drillPrefix}
+                getSearchText={(drillPrefix) => drillPrefix}
+                onSelect={handleSelectByDrillPrefix}
+                emptyMessage={
                     <div>
                         <T keyName="toolbar.select.noDrillPrefixesToSelect" />
                     </div>
-                )}
-            </div>
+                }
+                ariaLabel="Select drill prefixes"
+                recentCategory="drillPrefix"
+            />
         </ToolbarSection>
     );
 }
 
 function FamilySelector({ marchers }: { marchers: Marcher[] }) {
+    const { t } = useTranslate();
     const sections = sectionsFromMarchers(marchers ?? []);
     const { selectMarcherIds } = useHandleSelect({
         allMarchers: marchers ?? [],
     });
     const families = Object.values(FAMILIES);
     const handleSelectByFamily = useCallback(
-        (e: React.MouseEvent<HTMLButtonElement>, family: SectionFamily) => {
-            e.preventDefault();
+        (family: SectionFamily, options?: { shiftKey?: boolean }) => {
             const sectionsToSelect = sections.filter(
                 (section) => section.family.name === family.name,
             );
@@ -287,26 +266,22 @@ function FamilySelector({ marchers }: { marchers: Marcher[] }) {
             const marcherIdsToSelect = marchers
                 .filter((marcher) => sectionNames.has(marcher.section))
                 .map((marcher) => marcher.id);
-            selectMarcherIds(e, marcherIdsToSelect);
+            selectMarcherIds(marcherIdsToSelect, options);
         },
         [marchers, sections, selectMarcherIds],
     );
 
     return (
         <ToolbarSection aria-label="Select families">
-            <div className="flex gap-8">
-                {families.map((family, index) => (
-                    <div key={family.name} className="flex items-center gap-8">
-                        <button
-                            className="hover:text-accent flex items-center gap-8 outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:opacity-50"
-                            onClick={(e) => handleSelectByFamily(e, family)}
-                        >
-                            <T keyName={family.tName} />
-                        </button>
-                        {index < families.length - 1 && <Separator />}
-                    </div>
-                ))}
-            </div>
+            <ChipSelector
+                items={families}
+                getId={(family) => family.name}
+                getLabel={(family) => <T keyName={family.tName} />}
+                getSearchText={(family) => t(family.tName)}
+                onSelect={handleSelectByFamily}
+                ariaLabel="Select families"
+                recentCategory="family"
+            />
         </ToolbarSection>
     );
 }

--- a/apps/desktop/src/components/toolbar/tabs/SelectTab.tsx
+++ b/apps/desktop/src/components/toolbar/tabs/SelectTab.tsx
@@ -174,12 +174,12 @@ function TagSelector({ marchers }: { marchers: Marcher[] }) {
         (tag: DatabaseTag, options?: { shiftKey?: boolean }) => {
             if (!marcherIdsForTagsLoaded) {
                 console.error("Marcher IDs for tags not loaded");
-                return;
+                return false;
             }
             const marcherIds = marcherIdsForTags.get(tag.id);
             if (marcherIds == null) {
                 console.error(`Marcher IDs for tag ${tag.id} not found`);
-                return;
+                return false;
             }
             selectMarcherIds(marcherIds, options);
         },
@@ -189,7 +189,9 @@ function TagSelector({ marchers }: { marchers: Marcher[] }) {
     return (
         <ToolbarSection aria-label="Select tags">
             <ChipSelector
-                items={tagsLoaded ? (tags ?? []) : []}
+                items={
+                    tagsLoaded && marcherIdsForTagsLoaded ? (tags ?? []) : []
+                }
                 getId={(tag) => tag.id}
                 getLabel={(tag) =>
                     getTagName({ tag_id: tag.id, name: tag.name })

--- a/apps/desktop/src/components/toolbar/tabs/SelectTab.tsx
+++ b/apps/desktop/src/components/toolbar/tabs/SelectTab.tsx
@@ -282,7 +282,6 @@ function FamilySelector({ marchers }: { marchers: Marcher[] }) {
                 getSearchText={(family) => t(family.tName)}
                 onSelect={handleSelectByFamily}
                 ariaLabel="Select families"
-                recentCategory="family"
             />
         </ToolbarSection>
     );

--- a/apps/desktop/src/components/toolbar/tabs/__test__/chipSelectorRecents.test.ts
+++ b/apps/desktop/src/components/toolbar/tabs/__test__/chipSelectorRecents.test.ts
@@ -73,6 +73,17 @@ describe("resolveRecentItems", () => {
             items.slice(0, 6),
         );
     });
+
+    it("includes each matching id at most once", () => {
+        expect(resolveRecentItems(items, ["c", "c", "a"], getId)).toEqual([
+            { id: "c" },
+            { id: "a" },
+            { id: "b" },
+            { id: "d" },
+            { id: "e" },
+            { id: "f" },
+        ]);
+    });
 });
 
 describe("readRecentIds / writeRecentIds", () => {
@@ -96,5 +107,11 @@ describe("readRecentIds / writeRecentIds", () => {
     it("returns an empty list for corrupt storage", () => {
         localStorage.setItem(SELECT_TAB_RECENTS_STORAGE_KEY, "not-json");
         expect(readRecentIds("section")).toEqual([]);
+    });
+
+    it("recovers when existing storage is a JSON array", () => {
+        localStorage.setItem(SELECT_TAB_RECENTS_STORAGE_KEY, "[]");
+        writeRecentIds("section", ["Trumpet"]);
+        expect(readRecentIds("section")).toEqual(["Trumpet"]);
     });
 });

--- a/apps/desktop/src/components/toolbar/tabs/__test__/chipSelectorRecents.test.ts
+++ b/apps/desktop/src/components/toolbar/tabs/__test__/chipSelectorRecents.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+    pushRecentId,
+    readRecentIds,
+    resolveRecentItems,
+    SELECT_TAB_RECENTS_STORAGE_KEY,
+    writeRecentIds,
+} from "../chipSelectorRecents";
+
+const items = [
+    { id: "a" },
+    { id: "b" },
+    { id: "c" },
+    { id: "d" },
+    { id: "e" },
+    { id: "f" },
+    { id: "g" },
+];
+const getId = (item: { id: string }) => item.id;
+
+describe("pushRecentId", () => {
+    it("prepends the id in LIFO order", () => {
+        expect(pushRecentId(["b", "c"], "a")).toEqual(["a", "b", "c"]);
+    });
+
+    it("moves a duplicate to the front", () => {
+        expect(pushRecentId(["a", "b", "c"], "b")).toEqual(["b", "a", "c"]);
+    });
+
+    it("caps the list at 6", () => {
+        expect(pushRecentId(["a", "b", "c", "d", "e", "f"], "g")).toEqual([
+            "g",
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+        ]);
+    });
+});
+
+describe("resolveRecentItems", () => {
+    it("falls back to the first 6 items when recents are empty", () => {
+        expect(resolveRecentItems(items, [], getId)).toEqual(items.slice(0, 6));
+    });
+
+    it("returns recents in LIFO order", () => {
+        expect(resolveRecentItems(items, ["g", "c", "a"], getId)).toEqual([
+            { id: "g" },
+            { id: "c" },
+            { id: "a" },
+        ]);
+    });
+
+    it("skips stale ids", () => {
+        expect(
+            resolveRecentItems(items, ["missing", "c", "gone", "a"], getId),
+        ).toEqual([{ id: "c" }, { id: "a" }]);
+    });
+
+    it("falls back to the first 6 items when every recent id is stale", () => {
+        expect(resolveRecentItems(items, ["missing", "gone"], getId)).toEqual(
+            items.slice(0, 6),
+        );
+    });
+});
+
+describe("readRecentIds / writeRecentIds", () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it("returns an empty list when nothing is stored", () => {
+        expect(readRecentIds("section")).toEqual([]);
+    });
+
+    it("round-trips a category without clobbering others", () => {
+        writeRecentIds("section", ["Trumpet", "Flute"]);
+        writeRecentIds("tag", ["12"]);
+
+        expect(readRecentIds("section")).toEqual(["Trumpet", "Flute"]);
+        expect(readRecentIds("tag")).toEqual(["12"]);
+        expect(readRecentIds("family")).toEqual([]);
+    });
+
+    it("returns an empty list for corrupt storage", () => {
+        localStorage.setItem(SELECT_TAB_RECENTS_STORAGE_KEY, "not-json");
+        expect(readRecentIds("section")).toEqual([]);
+    });
+});

--- a/apps/desktop/src/components/toolbar/tabs/__test__/chipSelectorRecents.test.ts
+++ b/apps/desktop/src/components/toolbar/tabs/__test__/chipSelectorRecents.test.ts
@@ -23,8 +23,8 @@ describe("pushRecentId", () => {
         expect(pushRecentId(["b", "c"], "a")).toEqual(["a", "b", "c"]);
     });
 
-    it("moves a duplicate to the front", () => {
-        expect(pushRecentId(["a", "b", "c"], "b")).toEqual(["b", "a", "c"]);
+    it("leaves an existing id in place", () => {
+        expect(pushRecentId(["a", "b", "c"], "b")).toEqual(["a", "b", "c"]);
     });
 
     it("caps the list at 6", () => {
@@ -44,18 +44,28 @@ describe("resolveRecentItems", () => {
         expect(resolveRecentItems(items, [], getId)).toEqual(items.slice(0, 6));
     });
 
-    it("returns recents in LIFO order", () => {
+    it("returns recents in LIFO order, then fills remaining slots", () => {
         expect(resolveRecentItems(items, ["g", "c", "a"], getId)).toEqual([
             { id: "g" },
             { id: "c" },
             { id: "a" },
+            { id: "b" },
+            { id: "d" },
+            { id: "e" },
         ]);
     });
 
-    it("skips stale ids", () => {
+    it("skips stale ids and fills remaining slots", () => {
         expect(
             resolveRecentItems(items, ["missing", "c", "gone", "a"], getId),
-        ).toEqual([{ id: "c" }, { id: "a" }]);
+        ).toEqual([
+            { id: "c" },
+            { id: "a" },
+            { id: "b" },
+            { id: "d" },
+            { id: "e" },
+            { id: "f" },
+        ]);
     });
 
     it("falls back to the first 6 items when every recent id is stale", () => {

--- a/apps/desktop/src/components/toolbar/tabs/chipSelectorRecents.ts
+++ b/apps/desktop/src/components/toolbar/tabs/chipSelectorRecents.ts
@@ -1,0 +1,80 @@
+export const SELECT_TAB_RECENTS_STORAGE_KEY = "openmarch-select-tab-recents";
+export const DEFAULT_MAX_VISIBLE_CHIPS = 6;
+
+export type RecentsByCategory = Record<string, string[]>;
+
+/** Prepend `id` (LIFO), drop duplicates, and cap at `max`. */
+export function pushRecentId(
+    ids: string[],
+    id: string,
+    max = DEFAULT_MAX_VISIBLE_CHIPS,
+): string[] {
+    return [id, ...ids.filter((existing) => existing !== id)].slice(0, max);
+}
+
+/**
+ * Resolve stored recent ids against the current item list.
+ * Stale ids are skipped. If nothing valid remains, fall back to the first `maxVisible` items.
+ */
+export function resolveRecentItems<T>(
+    items: T[],
+    recentIds: string[],
+    getId: (item: T) => string | number,
+    maxVisible = DEFAULT_MAX_VISIBLE_CHIPS,
+): T[] {
+    const byId = new Map(items.map((item) => [String(getId(item)), item]));
+    const recents: T[] = [];
+    for (const id of recentIds) {
+        const item = byId.get(id);
+        if (item !== undefined) {
+            recents.push(item);
+            if (recents.length >= maxVisible) break;
+        }
+    }
+    if (recents.length === 0) return items.slice(0, maxVisible);
+    return recents;
+}
+
+export function readRecentIds(category: string): string[] {
+    try {
+        const stored = localStorage.getItem(SELECT_TAB_RECENTS_STORAGE_KEY);
+        if (!stored) return [];
+        const parsed = JSON.parse(stored) as RecentsByCategory;
+        const ids = parsed[category];
+        if (!Array.isArray(ids)) return [];
+        return ids.filter((id): id is string => typeof id === "string");
+    } catch (error) {
+        console.error(
+            "Failed to load select tab recents from localStorage:",
+            error,
+        );
+        return [];
+    }
+}
+
+export function writeRecentIds(category: string, ids: string[]): void {
+    try {
+        let parsed: RecentsByCategory = {};
+        const stored = localStorage.getItem(SELECT_TAB_RECENTS_STORAGE_KEY);
+        if (stored) {
+            try {
+                const existing = JSON.parse(stored) as RecentsByCategory;
+                if (existing && typeof existing === "object") {
+                    parsed = existing;
+                }
+            } catch {
+                parsed = {};
+            }
+        }
+        parsed[category] = ids;
+        localStorage.setItem(
+            SELECT_TAB_RECENTS_STORAGE_KEY,
+            JSON.stringify(parsed),
+        );
+    } catch (error) {
+        console.error(
+            "Failed to save select tab recents to localStorage:",
+            error,
+        );
+    }
+}

--- a/apps/desktop/src/components/toolbar/tabs/chipSelectorRecents.ts
+++ b/apps/desktop/src/components/toolbar/tabs/chipSelectorRecents.ts
@@ -3,18 +3,21 @@ export const DEFAULT_MAX_VISIBLE_CHIPS = 6;
 
 export type RecentsByCategory = Record<string, string[]>;
 
-/** Prepend `id` (LIFO), drop duplicates, and cap at `max`. */
+/** If `id` is already present, leave order unchanged. Otherwise prepend and cap at `max`. */
 export function pushRecentId(
     ids: string[],
     id: string,
     max = DEFAULT_MAX_VISIBLE_CHIPS,
 ): string[] {
-    return [id, ...ids.filter((existing) => existing !== id)].slice(0, max);
+    if (ids.includes(id)) return ids;
+    return [id, ...ids].slice(0, max);
 }
 
 /**
  * Resolve stored recent ids against the current item list.
- * Stale ids are skipped. If nothing valid remains, fall back to the first `maxVisible` items.
+ * Valid recents come first; leftover slots are filled with the remaining items
+ * in their original order, capped at `maxVisible`. Stale ids are skipped.
+ * If nothing valid remains, fall back to the first `maxVisible` items.
  */
 export function resolveRecentItems<T>(
     items: T[],
@@ -32,7 +35,14 @@ export function resolveRecentItems<T>(
         }
     }
     if (recents.length === 0) return items.slice(0, maxVisible);
-    return recents;
+
+    const recentIdSet = new Set(recents.map((item) => String(getId(item))));
+    const filled = [...recents];
+    for (const item of items) {
+        if (filled.length >= maxVisible) break;
+        if (!recentIdSet.has(String(getId(item)))) filled.push(item);
+    }
+    return filled;
 }
 
 export function readRecentIds(category: string): string[] {

--- a/apps/desktop/src/components/toolbar/tabs/chipSelectorRecents.ts
+++ b/apps/desktop/src/components/toolbar/tabs/chipSelectorRecents.ts
@@ -27,9 +27,12 @@ export function resolveRecentItems<T>(
 ): T[] {
     const byId = new Map(items.map((item) => [String(getId(item)), item]));
     const recents: T[] = [];
+    const seen = new Set<string>();
     for (const id of recentIds) {
+        if (seen.has(id)) continue;
         const item = byId.get(id);
         if (item !== undefined) {
+            seen.add(id);
             recents.push(item);
             if (recents.length >= maxVisible) break;
         }
@@ -69,7 +72,11 @@ export function writeRecentIds(category: string, ids: string[]): void {
         if (stored) {
             try {
                 const existing = JSON.parse(stored) as RecentsByCategory;
-                if (existing && typeof existing === "object") {
+                if (
+                    existing &&
+                    typeof existing === "object" &&
+                    !Array.isArray(existing)
+                ) {
                     parsed = existing;
                 }
             } catch {

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -108,6 +108,7 @@ words:
   - Pyware
   - Rcoords
   - rels
+  - recents
   - rgba
   - ritardandos
   - rootfile


### PR DESCRIPTION
## What
Select tab identifiers (sections, tags, drill prefixes, families) overflow into a searchable dropdown after 6 chips and remember recently used items.

## How
- Extract a shared `ChipSelector` from `SelectTab`
- Persist LIFO recents per category in localStorage; leave order unchanged if the item is already visible
- Portaled, keyboard-navigable search dropdown when the list exceeds the chip cap

## Notes
- Unit tests cover recents push, resolve, and storage

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable chip selectors for sections, tags, drill prefixes, and families.
  * Added keyboard navigation, multi-select support, accessibility improvements, and configurable visible-chip limits.
  * Added recent selections that are remembered and displayed for quicker access.
  * Added localized text for search, recent selections, and empty results.

* **Tests**
  * Added coverage for recent-selection behavior, storage handling, duplicate items, and invalid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->