### PR TITLE
Add .cursor/rules reference files for IDE agent context

### DIFF
--- a/.cursor/rules/localization.mdc
+++ b/.cursor/rules/localization.mdc
@@ -1,0 +1,60 @@
+---
+description: When adding or changing user-facing text; use Tolgee/i18n and keep en.json in sync
+alwaysApply: false
+---
+
+# Localization (i18n)
+
+OpenMarch uses **Tolgee** with React. User-facing strings must use translation keys. Developers do not need Tolgee API keys; add keys in code and in the English file only. Other languages are handled via Tolgee by the team.
+
+## Translation file
+
+- **Path**: `apps/desktop/i18n/en.json`
+- **Structure**: Nested JSON by feature/section (e.g. `inspector.prop`, `marchers.deleteButton`).
+- **In code**: Reference keys with dot notation, e.g. `inspector.prop.geometry`.
+
+## In components
+
+### Simple text: `<T>` component
+
+```tsx
+import { T } from "@tolgee/react";
+
+<T keyName="inspector.prop.title" />
+```
+
+### With parameters (interpolation)
+
+```tsx
+<T keyName="inspector.prop.pageSubtitle" params={{ pageName: selectedPage.name }} />
+```
+
+In `en.json`: `"pageSubtitle": "Page {pageName}"`
+
+### In logic or when you need the string: `useTranslate`
+
+```tsx
+import { useTranslate } from "@tolgee/react";
+
+const { t } = useTranslate();
+const label = t("inspector.prop.name");
+// With params:
+const msg = t("inspector.prop.deleteConfirmDescription");
+```
+
+### Collapsible / modal titles
+
+- `InspectorCollapsible` accepts **translatableTitle**: `translatableTitle={{ keyName: "inspector.prop.title" }}` (not a raw string or `<T>`).
+- For AlertModal (global store): set title to the **key name** string; the modal renders it with `<T keyName={title} />`.
+
+## Workflow
+
+1. **Add keys in code** using `<T keyName="section.feature.key" />` or `t("section.feature.key")`.
+2. **Add the same keys and English text** to `apps/desktop/i18n/en.json` under the matching nested structure.
+3. **Do not edit** other language files (es.json, fr.json, etc.); those are synced via Tolgee.
+
+## Conventions
+
+- **Key naming**: `section.subsection.key` in lowercase/camelCase (e.g. `inspector.prop.deleteConfirmTitle`).
+- **No hardcoded UI text**: All user-visible strings go through keys.
+- **Reuse when possible**: e.g. `marchers.deleteButton`, `marchers.cancelDeleteButton` for delete confirmations across features.

--- a/.cursor/rules/ref-architecture.mdc
+++ b/.cursor/rules/ref-architecture.mdc
@@ -1,0 +1,119 @@
+---
+description: When needing to understand the overall project structure, directory layout, tech stack, or data flow patterns
+alwaysApply: false
+---
+
+# Project Architecture Reference
+
+## Overview
+
+OpenMarch is an Electron + React desktop app for writing drill (marching band formations). It uses a monorepo structure with `apps/desktop` as the main app. The renderer process handles all business logic and database queries via a SQLite proxy to the main process.
+
+## Tech Stack
+
+- **Runtime**: Electron (main + renderer processes)
+- **UI**: React 18, Tailwind CSS, Radix UI primitives
+- **State**: Zustand (UI state), React Context (tree state), TanStack React Query (server/DB state)
+- **Database**: SQLite via libsql, Drizzle ORM with SQLite proxy pattern
+- **Canvas**: Fabric.js for drill field rendering
+- **Build**: Vite + vite-plugin-electron, pnpm workspaces
+- **Testing**: Vitest (unit), Playwright (e2e)
+- **Icons**: @phosphor-icons/react
+
+## Directory Map
+
+```
+apps/desktop/
+├── electron/                      # Main process code
+│   ├── main/index.ts             # Electron entry, window mgmt, IPC
+│   ├── preload/index.ts          # Context bridge (window.electron API)
+│   └── database/
+│       ├── db.ts                 # Main process DB connection (libsql)
+│       ├── database.services.ts  # SQL proxy IPC handlers
+│       ├── migrations/
+│       │   ├── schema.ts         # Drizzle schema (all tables)
+│       │   ├── relations.ts      # Table relations
+│       │   ├── triggers.ts       # History triggers SQL
+│       │   └── *.sql             # Migration files
+│       └── services/
+│           └── DrizzleMigrationService.ts
+├── src/
+│   ├── main.tsx                  # React entry (providers)
+│   ├── App.tsx                   # Root component (LaunchPage vs workspace)
+│   ├── components/               # React UI components
+│   │   ├── canvas/               # Canvas + listeners + hooks
+│   │   ├── timeline/             # Timeline + audio components
+│   │   ├── inspector/            # Right panel editors
+│   │   ├── toolbar/              # Top toolbar + tabs
+│   │   ├── sidebar/              # Left sidebar + modals
+│   │   ├── marcher/              # Marcher CRUD + appearance
+│   │   ├── prop/                 # Prop CRUD + drawing
+│   │   ├── field/                # Field properties config
+│   │   ├── music/                # Music/tempo/metronome
+│   │   ├── exporting/            # Coordinate sheets + PDF
+│   │   ├── tags/                 # Tag management
+│   │   ├── launchpage/           # Start screen + settings
+│   │   ├── titlebar/             # Window title bar
+│   │   └── singletons/           # StateInitializer
+│   ├── global/
+│   │   ├── classes/              # Domain entities (Marcher, Page, Beat, etc.)
+│   │   │   ├── canvasObjects/    # Fabric.js wrappers (CanvasMarcher, etc.)
+│   │   │   └── fieldTemplates/   # Football, Indoor templates
+│   │   └── database/
+│   │       └── db.ts             # Renderer DB connection (proxy)
+│   ├── db-functions/             # Database CRUD operations
+│   │   ├── index.ts              # Barrel exports
+│   │   ├── types.ts              # DbConnection, DbTransaction types
+│   │   ├── history.ts            # transactionWithHistory, undo/redo
+│   │   └── [entity].ts           # Per-entity CRUD
+│   ├── hooks/
+│   │   ├── queries/              # React Query hooks per entity
+│   │   │   ├── index.ts          # Barrel exports
+│   │   │   └── use[Entity].ts    # Query/mutation options
+│   │   ├── useTimingObjects.ts   # Multi-query: pages+beats+measures
+│   │   └── useAnimation.ts       # Canvas animation during playback
+│   ├── stores/                   # Zustand stores (UI state)
+│   ├── context/                  # React Context providers
+│   ├── utilities/                # Helper functions
+│   └── settings/                 # Workspace settings
+```
+
+## Data Flow
+
+```
+Database (SQLite)
+    ↕ SQL via IPC proxy
+Renderer DB (src/global/database/db.ts)
+    ↕ Drizzle ORM queries
+DB Functions (src/db-functions/*.ts)
+    ↕ called by
+React Query Hooks (src/hooks/queries/use*.ts)
+    ↕ provides data to
+React Components (src/components/)
+    ↕ reads UI state from
+Zustand Stores (src/stores/*.ts)
+    ↕ reads tree state from
+React Context (src/context/*.tsx)
+```
+
+### Three State Categories
+
+1. **Server/DB state** → React Query: All entity data (marchers, pages, shapes, etc.). Cached, auto-invalidated on mutations.
+2. **UI state** → Zustand: Canvas zoom/pan, selection, drawing mode, modals, settings. Persisted to localStorage where needed.
+3. **Tree state** → React Context: Selected page, selected marchers, playback state, theme. Shared across component tree.
+
+## App Entry Flow
+
+1. `main.tsx` → wraps in `ThemeProvider`, `PostHogProvider`, `TolgeeProvider`, `QueryClientProvider`
+2. `App.tsx` → checks `databaseIsReady`. Shows `LaunchPage` if not, main workspace if yes.
+3. Main workspace layout: `TitleBar` (top) → `Toolbar` → `Sidebar` (left) + `Canvas` (center) + `Inspector` (right) → `TimelineContainer` (bottom)
+4. `StateInitializer` prefetches queries, selects first page, loads audio file on mount.
+
+## Key Conventions
+
+- **Imports**: Use `@/` alias for `src/` directory
+- **Barrel exports**: `db-functions/index.ts` and `hooks/queries/index.ts` re-export everything
+- **Naming**: DB functions in `camelCase.ts`, query hooks in `use[PascalCase].ts`, stores in `[PascalCase]Store.ts`
+- **Components**: Co-located with feature (e.g., `components/marcher/` has list, modal, form)
+- **Styles**: Tailwind CSS classes inline, shared styles in `packages/ui/src/tailwind.css`
+- **Base components**: Reusable buttons, inputs, etc. in `packages/ui/src/components/base/`

--- a/.cursor/rules/ref-canvas.mdc
+++ b/.cursor/rules/ref-canvas.mdc
@@ -1,0 +1,169 @@
+---
+description: When working with the canvas, Fabric.js, canvas listeners, selection, rendering, or canvas objects
+alwaysApply: false
+---
+
+# Canvas System Reference
+
+## Overview
+
+The canvas is the central visual component where the drill field, marchers, props, shapes, and paths are rendered. It uses Fabric.js (custom `OpenMarchCanvas` extending `fabric.Canvas`) wrapped by a React component. User interactions are handled through a listener architecture with separate listener classes for different modes (default, line, lasso, prop drawing).
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/global/classes/canvasObjects/OpenMarchCanvas.ts` | Custom Fabric.js canvas class |
+| `src/components/canvas/Canvas.tsx` | React wrapper component |
+| `src/components/canvas/CanvasConstants.ts` | Canvas constants |
+| `src/components/canvas/CanvasZoomControls.tsx` | Zoom control UI |
+| **Listeners** | |
+| `src/components/canvas/listeners/CanvasListeners.ts` | Base listener interface/class |
+| `src/components/canvas/listeners/DefaultListeners.ts` | Default mode (select, drag) |
+| `src/components/canvas/listeners/LineListeners.ts` | Line drawing mode |
+| `src/components/canvas/listeners/LassoListeners.ts` | Lasso selection mode |
+| `src/components/canvas/listeners/PropDrawingListeners.ts` | Prop drawing mode |
+| `src/components/canvas/listeners/CodegenListeners.ts` | Codegen mode |
+| **Hooks** | |
+| `src/components/canvas/hooks/canvasListeners.selection.ts` | Selection handling |
+| `src/components/canvas/hooks/canvasListeners.movement.ts` | Movement handling |
+| `src/components/canvas/hooks/editablePath.tsx` | Editable path controls |
+| `src/components/canvas/hooks/shapes.ts` | Shape rendering hooks |
+| **Canvas Objects** | |
+| `src/global/classes/canvasObjects/CanvasMarcher.ts` | Marcher on canvas |
+| `src/global/classes/canvasObjects/CanvasProp.ts` | Prop on canvas |
+| `src/global/classes/canvasObjects/MarcherLine.ts` | Line between marchers |
+| `src/global/classes/canvasObjects/CollisionMarker.ts` | Collision indicator |
+| `src/global/classes/canvasObjects/Pathway.ts` | Path visualization |
+| `src/global/classes/canvasObjects/Midpoint.ts` | Midpoint marker |
+| `src/global/classes/canvasObjects/Endpoint.ts` | Endpoint marker |
+| `src/global/classes/canvasObjects/ControlPoint.ts` | Path control point |
+| `src/global/classes/canvasObjects/MarcherShape.ts` | Shape on canvas |
+| `src/global/classes/canvasObjects/interfaces/Selectable.ts` | Selectable interface |
+| **Stores** | |
+| `src/stores/CanvasStore.ts` | Canvas instance + viewport |
+| `src/stores/SelectionStore.ts` | Selected shape page IDs |
+| `src/stores/AlignmentEventStore.ts` | Alignment tool state |
+| `src/stores/CollisionStore.ts` | Collision data per page |
+
+## OpenMarchCanvas
+
+The core canvas class extends `fabric.Canvas`:
+
+```typescript
+class OpenMarchCanvas extends fabric.Canvas {
+    // Key properties
+    currentPage: Page | null;
+    fieldProperties: FieldProperties;
+    uiSettings: UiSettings;
+    marcherShapes: MarcherShape[];
+
+    // Rendering methods
+    renderMarchers(marchersWithVisuals, selectedPage);
+    renderPathVisuals(marchersWithVisuals, selectedPage);
+    renderFieldGrid(fieldProperties);
+    renderShapes(shapePages, selectedPage);
+    renderCollisionMarkers(collisions);
+
+    // Selection
+    setActiveObjects(objects);
+    getActiveObjects(): fabric.Object[];
+}
+```
+
+## Rendering Pipeline
+
+When the selected page changes:
+
+1. **Field grid** - Grid lines, yard lines, hash marks based on `FieldProperties`
+2. **Marchers** - `CanvasMarcher` objects positioned at their MarcherPage coordinates
+3. **Props** - `CanvasProp` objects with their per-page geometry
+4. **Shapes** - `MarcherShape` objects showing formation outlines
+5. **Pathways** - `Pathway` objects showing movement paths between pages
+6. **Collision markers** - `CollisionMarker` objects at collision points
+
+## Listener Architecture
+
+The canvas uses swappable listener classes for different interaction modes:
+
+```typescript
+// Base pattern - each listener class implements mouse/keyboard handlers
+interface CanvasListeners {
+    onMouseDown(event: fabric.TPointerEventInfo): void;
+    onMouseMove(event: fabric.TPointerEventInfo): void;
+    onMouseUp(event: fabric.TPointerEventInfo): void;
+    onKeyDown(event: KeyboardEvent): void;
+    cleanup(): void;
+}
+```
+
+Active listeners are determined by the current mode:
+- **Default mode** → `DefaultListeners` (select, drag, move marchers)
+- **Line mode** → `LineListeners` (draw alignment lines)
+- **Lasso mode** → `LassoListeners` (lasso selection)
+- **Prop drawing** → `PropDrawingListeners` (draw prop shapes)
+- **Codegen** → `CodegenListeners` (code generation mode)
+
+## Canvas Store (Zustand)
+
+```typescript
+import { useCanvasStore } from "@/stores/CanvasStore";
+
+const {
+    canvas,           // OpenMarchCanvas | null
+    viewport,         // { zoom, panX, panY }
+    setCanvas,        // Set canvas instance
+    zoomToFit,        // Zoom to fit all objects (or specific ones)
+    zoomToCollisions,  // Zoom to collision area
+    resetViewport,    // Reset to zoom=1, pan=0,0
+    setViewport,      // Manual zoom/pan
+} = useCanvasStore();
+```
+
+## Selectable Interface
+
+Canvas objects that can be selected implement:
+
+```typescript
+interface Selectable {
+    readonly marcherId: number;
+    readonly isSelectable: boolean;
+    select(): void;
+    deselect(): void;
+}
+```
+
+Used by `CanvasMarcher`, `CanvasProp`, and other interactive objects.
+
+## Selection Flow
+
+1. User clicks/drags on canvas → `DefaultListeners.onMouseDown`
+2. Selection hooks (`canvasListeners.selection.ts`) determine what was clicked
+3. `SelectedMarchersContext` updated with selected marcher IDs
+4. Canvas highlights selected objects
+5. `Inspector` panel shows editors for selected items
+
+## Canvas.tsx React Component
+
+The React wrapper in `Canvas.tsx`:
+- Creates `OpenMarchCanvas` on mount, stores in `CanvasStore`
+- Subscribes to: marchers, marcherPages, props, propGeometries, fieldProperties, appearances, shapes
+- On data change: calls `canvas.renderMarchers()`, `canvas.renderPathVisuals()`, etc.
+- On page change: re-renders all objects for new page
+- On selection change: syncs with `SelectedMarchersContext`
+- Wires stores: `useCanvasStore`, `useUiSettingsStore`, `usePropDrawingStore`, `useAlignmentEventStore`, `useCollisionStore`, `useSelectionStore`, `useFullscreenStore`
+
+## Integration Points
+
+- **Stores**: CanvasStore (instance), SelectionStore, AlignmentEventStore, CollisionStore, PropDrawingStore
+- **Context**: SelectedPageContext (which page to render), SelectedMarchersContext (highlighted marchers)
+- **Queries**: marchers, marcherPages, fieldProperties, shapes, props, appearances
+- **Animation**: `useAnimation` hook drives canvas updates during playback
+
+## Gotchas
+
+- The canvas is NOT React-rendered content. It's an imperative Fabric.js canvas. React manages data flow, but rendering is manual via `canvas.render*()` methods.
+- Always access canvas through `useCanvasStore()`, never hold direct references.
+- Canvas objects (CanvasMarcher, etc.) store references to domain data. They must be refreshed when data changes.
+- Viewport transforms use Fabric.js format: `[scaleX, 0, 0, scaleY, translateX, translateY]`.
+- Selection state lives in both SelectedMarchersContext (React) and canvas active objects (Fabric.js) - they must stay in sync.

--- a/.cursor/rules/ref-database.mdc
+++ b/.cursor/rules/ref-database.mdc
@@ -1,0 +1,174 @@
+---
+description: When working with database schema, migrations, transactions, undo/redo, or Drizzle ORM queries
+alwaysApply: false
+---
+
+# Database & Schema Reference
+
+## Overview
+
+OpenMarch uses SQLite (libsql) with Drizzle ORM. The renderer process executes queries through a SQLite proxy that communicates with the main process via IPC. All mutations use `transactionWithHistory()` for automatic undo/redo support.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `electron/database/migrations/schema.ts` | Drizzle schema (all tables) |
+| `electron/database/migrations/relations.ts` | Table relations |
+| `electron/database/db.ts` | Main process DB connection (libsql) |
+| `src/global/database/db.ts` | Renderer DB connection (proxy) |
+| `src/db-functions/history.ts` | `transactionWithHistory`, undo/redo system |
+| `src/db-functions/types.ts` | `DbConnection`, `DbTransaction` types |
+| `electron/database/database.services.ts` | SQL proxy IPC handlers |
+| `electron/database/services/DrizzleMigrationService.ts` | Migration runner |
+
+## Database Tables
+
+### Core Entities
+- `marchers` - Performers (section, drill_prefix, drill_order, name, type)
+- `pages` - Drill pages (name, counts, order, start_beat FK)
+- `beats` - Timing points (position, duration, include_in_measure)
+- `measures` - Musical measures (start_beat FK, number, rehearsal_mark)
+- `marcher_pages` - Marcher position per page (x, y, rotation, appearance overrides)
+
+### Props
+- `props` - Props/equipment (marcher_id FK, surface_type, default dimensions)
+- `prop_page_geometry` - Prop geometry per page (shape_type, width, height, rotation)
+
+### Shapes
+- `shapes` - Shape definitions (name)
+- `shape_pages` - Shape per page (svg_path, notes)
+- `shape_page_marchers` - Marcher-to-shape assignments (position on shape)
+
+### Pathways
+- `pathways` - Path data between positions (path_data text, notes)
+
+### Appearances
+- `section_appearances` - Section-level visual defaults
+- `tags` - Tag definitions (name, color)
+- `tag_appearances` - Tag visual overrides per page
+- `marcher_tags` - Marcher-to-tag assignments
+
+### Audio & Settings
+- `audio_files` - Audio file metadata (path, nickname, selected)
+- `field_properties` - Field configuration JSON (singleton, id=1)
+- `utility` - Utility settings key-value store
+- `workspace_settings` - Workspace settings key-value store
+
+### History
+- `history_undo` - Undo stack (sequence, history_group, sql)
+- `history_redo` - Redo stack (sequence, history_group, sql)
+- `history_stats` - Current group counters (cur_undo_group, cur_redo_group, group_limit)
+
+### Views
+- `timing_objects` - Unified view joining pages, beats, measures
+
+## Renderer DB Connection
+
+The renderer uses a Drizzle proxy that sends SQL over IPC:
+
+```typescript
+// src/global/database/db.ts
+import { drizzle } from "drizzle-orm/sqlite-proxy";
+import * as schema from "../../../electron/database/migrations/schema";
+
+export const db = drizzle(
+    async (sql, params, method) => {
+        return await window.electron.sqlProxy(sql, params, method);
+    },
+    { schema, casing: "snake_case" },
+);
+
+export type DB = typeof db;
+export { schema };
+```
+
+## Type Inference
+
+Always use Drizzle-inferred types, never manually define interfaces that duplicate schema:
+
+```typescript
+import { schema } from "@/global/database/db";
+
+// Select type (what you get from queries)
+type DatabaseMarcher = typeof schema.marchers.$inferSelect;
+
+// Insert type (what you pass to inserts)
+type NewMarcherInsert = typeof schema.marchers.$inferInsert;
+
+// Custom args (omit auto-generated fields)
+type NewMarcherArgs = Omit<typeof schema.marchers.$inferInsert, "id" | "created_at" | "updated_at">;
+
+// Modified args (partial + required id)
+type ModifiedMarcherArgs = Partial<typeof schema.marchers.$inferInsert> & { id: number };
+```
+
+## Transaction Pattern
+
+All mutations MUST use `transactionWithHistory` for undo/redo:
+
+```typescript
+import { transactionWithHistory, DbConnection, DbTransaction } from "@/db-functions";
+import { schema } from "@/global/database/db";
+
+// InTransaction function - core logic, accepts tx
+export const createItemsInTransaction = async ({
+    newItems,
+    tx,
+}: {
+    newItems: NewItemArgs[];
+    tx: DbTransaction;
+}) => {
+    return await tx.insert(schema.table_name).values(newItems).returning();
+};
+
+// Standalone function - wraps InTransaction with history
+export async function createItems({
+    newItems,
+    db,
+}: {
+    newItems: NewItemArgs[];
+    db: DbConnection;
+}) {
+    return await transactionWithHistory(db, "createItems", async (tx) => {
+        return await createItemsInTransaction({ newItems, tx });
+    });
+}
+```
+
+**Key rule**: By default, only provide `InTransaction` functions. Standalone wrappers are only needed when the function will frequently be called on its own (not as part of a larger transaction).
+
+## Tables With History Tracking
+
+These tables have SQL triggers that auto-record changes to the undo stack:
+
+```
+beats, pages, measures, marchers, marcher_pages,
+shapes, shape_pages, shape_page_marchers,
+field_properties, section_appearances, utility,
+tags, tag_appearances, marcher_tags
+```
+
+Tables NOT tracked: `props`, `prop_page_geometry`, `pathways`, `audio_files`, `workspace_settings`, `history_*`
+
+## Undo/Redo System
+
+- SQL triggers on tracked tables capture INSERT/UPDATE/DELETE as reverse SQL statements
+- `transactionWithHistory()` groups all changes in one call into a single undo group
+- `performUndo(db)` / `performRedo(db)` execute the reverse SQL
+- Triggers switch between undo/redo mode during history actions
+- Global transaction lock prevents concurrent transactions (`window.__dbTransactionLock`)
+
+## Migrations
+
+- Generate: `pnpm migrate` in `apps/desktop/`
+- Files: `electron/database/migrations/0000_*.sql` through `0017_*.sql`
+- Runner: `DrizzleMigrationService.ts` - creates backup, disables triggers, applies migrations, recreates triggers
+- Version tracking: `PRAGMA user_version`
+
+## Gotchas
+
+- The `transactionWithHistory` function asserts that the history group was incremented exactly once. If your function doesn't modify any tracked table, the assertion fails.
+- `withTransactionLock()` is needed when using `db.transaction()` directly (without history).
+- Boolean values in SQLite are stored as `0|1` integers - transform in your db-functions layer.
+- The renderer DB proxy cannot execute raw SQL directly - use `window.electron.unsafeSqlProxy()` for trigger creation.

--- a/.cursor/rules/ref-electron-layer.mdc
+++ b/.cursor/rules/ref-electron-layer.mdc
@@ -1,0 +1,191 @@
+---
+description: When working with the Electron main process, preload script, IPC communication, file management, or app packaging
+alwaysApply: false
+---
+
+# Electron Architecture Reference
+
+## Overview
+
+OpenMarch uses Electron with strict context isolation. The main process manages the window, file system, database connection, and native APIs. The renderer process accesses these via a preload-bridge (`window.electron`). The SQL proxy pattern allows Drizzle ORM in the renderer to execute queries against the main process's libsql database.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `electron/main/index.ts` | Main process entry (window, IPC, lifecycle) |
+| `electron/preload/index.ts` | Preload bridge (`window.electron` API) |
+| `electron/database/db.ts` | Main process DB connection (libsql) |
+| `electron/database/database.services.ts` | SQL proxy + IPC handlers |
+| `electron/database/services/DrizzleMigrationService.ts` | Migration runner |
+| `electron/database/services/sqljs-driver.ts` | SQL.js driver (testing) |
+| `electron/database/migrations/schema.ts` | Drizzle schema |
+| `electron/database/migrations/triggers.ts` | History trigger SQL |
+| `electron/database/repair.ts` | Database repair utilities |
+| `electron-builder.json5` | Electron packaging config |
+
+## Security Model
+
+```typescript
+// Main process creates BrowserWindow with:
+{
+    contextIsolation: true,    // Renderer can't access Node.js
+    nodeIntegration: false,    // No require() in renderer
+    sandbox: true,             // Additional sandboxing
+}
+```
+
+All main process access goes through the preload script's `contextBridge.exposeInMainWorld()`.
+
+## Preload Bridge API
+
+`window.electron` exposes:
+
+```typescript
+interface ElectronAPI {
+    // SQL Proxy (core data access)
+    sqlProxy(sql: string, params: any[], method: string): Promise<any>;
+    unsafeSqlProxy(sql: string): Promise<void>;  // For trigger creation
+
+    // Database lifecycle
+    databaseIsReady(): Promise<boolean>;
+    databaseGetPath(): Promise<string>;
+    databaseCreate(filePath: string): Promise<void>;
+    databaseLoad(filePath: string): Promise<void>;
+    databaseSave(): Promise<void>;
+
+    // History
+    undo(): Promise<void>;
+    redo(): Promise<void>;
+    onHistoryAction(callback: Function): void;
+
+    // Window controls
+    minimizeWindow(): void;
+    maximizeWindow(): void;
+    closeWindow(): void;
+
+    // Export
+    export: {
+        pdf(html: string): Promise<Buffer>;
+        generateDocForMarcher(marcherId: number): Promise<Buffer>;
+    };
+
+    // Audio
+    getAudioFile(path: string): Promise<ArrayBuffer>;
+    saveAudioFile(data: ArrayBuffer, name: string): Promise<string>;
+    deleteAudioFile(path: string): Promise<void>;
+
+    // Recent files
+    getRecentFiles(): Promise<string[]>;
+    addRecentFile(path: string): Promise<void>;
+
+    // Logging
+    log(level: string, message: string): Promise<void>;
+}
+```
+
+## SQL Proxy Pattern
+
+The core data access mechanism:
+
+```
+Renderer (Drizzle ORM)
+  → generates SQL string + params
+  → calls window.electron.sqlProxy(sql, params, method)
+  → IPC to main process
+Main Process (database.services.ts)
+  → receives SQL via ipcMain.handle
+  → executes against libsql Database
+  → returns result rows
+  → IPC response to renderer
+Renderer
+  → Drizzle processes result into typed objects
+```
+
+```typescript
+// Main process handler (database.services.ts)
+ipcMain.handle("sql-proxy", async (_, sql, params, method) => {
+    return handleSqlProxyWithDb(database, sql, params, method);
+});
+
+// Renderer connection (src/global/database/db.ts)
+export const db = drizzle(
+    async (sql, params, method) => {
+        return await window.electron.sqlProxy(sql, params, method);
+    },
+    { schema, casing: "snake_case" },
+);
+```
+
+## Database File Management
+
+- File extension: `.dots`
+- User controls file location (File > Open / Save As)
+- Connection lifecycle:
+  1. `setDbPath(filePath)` - sets active database path
+  2. `connect()` - creates libsql `Database` instance
+  3. Foreign keys enabled: `PRAGMA foreign_keys = ON`
+  4. Migrations run on connect
+  5. History triggers created after migrations
+
+## Build & Packaging
+
+```json5
+// electron-builder.json5
+{
+    appId: "com.openmarch.app",
+    productName: "OpenMarch",
+    // File associations
+    fileAssociations: [{ ext: "dots", name: "OpenMarch File" }],
+    // Platforms
+    mac: { target: ["dmg", "zip"], hardenedRuntime: true, notarize: true },
+    win: { target: "nsis" },
+    linux: { target: ["snap", "AppImage"] },
+    // Native modules
+    asar: true,
+    asarUnpack: ["**/node_modules/@libsql/**"],
+    // Publishing
+    publish: { provider: "github" }
+}
+```
+
+Build output:
+- `dist-electron/main/` - main process bundle
+- `dist-electron/preload/` - preload script bundle
+- `dist/` - renderer (Vite build)
+
+## Vite Config
+
+```
+vite.config.mts
+├── @vitejs/plugin-react
+├── vite-plugin-electron (main + preload)
+├── vite-plugin-electron-renderer (Node.js in renderer for dev)
+├── @tailwindcss/vite
+└── @sentry/vite-plugin (source maps)
+```
+
+## Main Process Responsibilities
+
+1. **Window management** - BrowserWindow creation, lifecycle, menu
+2. **Database connection** - libsql Database instance, SQL proxy
+3. **File I/O** - .dots file open/save, audio files, recent files
+4. **PDF export** - `webContents.printToPDF()`
+5. **Auto-updater** - GitHub releases via electron-updater
+6. **Error reporting** - Sentry integration
+7. **IPC handlers** - All `ipcMain.handle()` registrations
+
+## Integration Points
+
+- **Renderer DB**: `src/global/database/db.ts` is the renderer's Drizzle instance using `window.electron.sqlProxy`
+- **History**: Undo/redo uses `window.electron.undo()` / `window.electron.redo()` which execute in main process
+- **Audio**: Audio files managed via IPC (main process file system access)
+- **Export**: PDF generation via main process
+
+## Gotchas
+
+- `unsafeSqlProxy` bypasses Drizzle's prepared statement system. Only used for trigger SQL that Drizzle can't handle.
+- In Vitest, `window.electron` doesn't exist. Tests use a mock SQL proxy (`setupTestSqlProxy()`).
+- libsql native module must be unpacked from ASAR (`asarUnpack` in builder config).
+- The preload script runs in a limited context - no full Node.js access, only what's explicitly bridged.
+- `PRAGMA foreign_keys = ON` must be set after every connection (it's per-connection in SQLite).

--- a/.cursor/rules/ref-exporting.mdc
+++ b/.cursor/rules/ref-exporting.mdc
@@ -1,0 +1,100 @@
+---
+description: When working with exporting, coordinate sheets, PDF export, SVG generation, or readable coordinates
+alwaysApply: false
+---
+
+# Export & Coordinate Sheets Reference
+
+## Overview
+
+OpenMarch can export coordinate sheets for individual marchers, showing their position on each page in human-readable field coordinates (e.g., "4 steps inside the left 35 yard line"). Exports are generated as PDF via the Electron main process.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/components/exporting/ExportCoordinatesModal.tsx` | Export dialog UI |
+| `src/components/exporting/MarcherCoordinateSheet.tsx` | Coordinate sheet layout |
+| `src/components/exporting/CoordinateSheetTemplates.tsx` | Sheet format templates |
+| `src/components/exporting/utils/svg-generator.ts` | SVG field diagram generator |
+| `src/global/classes/ReadableCoords.ts` | Pixel-to-readable coordinate conversion |
+| `src/global/classes/StepSize.ts` | Step size calculations |
+| `src/hooks/queries/useCoordinateData.ts` | Coordinate data query hook |
+
+## Coordinate System
+
+### ReadableCoords
+
+Converts pixel coordinates to human-readable field positions:
+
+```typescript
+// src/global/classes/ReadableCoords.ts
+// Input: x, y in canvas pixels
+// Output: e.g., "4 steps inside the left 35 yard line, 2 steps behind the front hash"
+
+// Uses field properties checkpoints to determine:
+// - Which yard line (or between which yard lines)
+// - How many steps from the reference point
+// - Which side of the field (left/right)
+// - Hash position (front/back hash, sideline)
+```
+
+Checkpoints are defined in `FieldProperties` and represent named positions on the field (yard lines, hashes, sidelines).
+
+### StepSize
+
+Calculates the step size between two positions:
+
+```typescript
+// src/global/classes/StepSize.ts
+// Given two MarcherPage positions and a count,
+// calculates the step size (distance per count)
+// Used in coordinate sheets to show movement difficulty
+```
+
+## Export Flow
+
+1. User opens `ExportCoordinatesModal` from toolbar
+2. Selects marchers and template format
+3. `MarcherCoordinateSheet` renders a printable layout:
+   - Header with marcher info (name, section, drill number)
+   - Table of pages with coordinates, step sizes, counts
+   - Optional field diagram SVGs showing position
+4. `svg-generator.ts` creates small field diagrams with a dot for position
+5. PDF generated via Electron main process IPC (`window.electron.export.pdf()`)
+
+## Coordinate Sheet Templates
+
+`CoordinateSheetTemplates.tsx` provides different layout formats:
+- Standard format (table with coordinates)
+- Compact format (minimal layout)
+- Custom format options
+
+## SVG Field Diagrams
+
+`svg-generator.ts` creates inline SVG images of the field showing:
+- Field outline and yard lines
+- A marker dot at the marcher's position
+- Used as visual aids in coordinate sheets
+
+## Query Hook
+
+```typescript
+import { useCoordinateData } from "@/hooks/queries/useCoordinateData";
+// Combines marcher data, page data, marcher pages, and field properties
+// to produce export-ready coordinate information
+```
+
+## Integration Points
+
+- **Field Properties**: Checkpoints determine coordinate labels. `pixelsPerStep` drives step size calculations.
+- **MarcherPage**: x, y positions are the source coordinates.
+- **Pages**: Page name, counts, and order structure the sheet.
+- **Electron**: PDF generation happens in the main process via IPC.
+
+## Gotchas
+
+- Coordinate readability depends entirely on field properties checkpoints. Missing checkpoints produce poor labels.
+- SVG generation is synchronous and can be slow for many pages.
+- PDF export uses Electron's `webContents.printToPDF()` - not available in browser-only mode.
+- Step size is calculated as straight-line distance / counts. Pathways don't affect it.

--- a/.cursor/rules/ref-field-properties.mdc
+++ b/.cursor/rules/ref-field-properties.mdc
@@ -1,0 +1,99 @@
+---
+description: When working with field properties, field configuration, field templates, field customization, or field themes
+alwaysApply: false
+---
+
+# Field Properties & Configuration Reference
+
+## Overview
+
+Field properties define the drill field's dimensions, grid, theme, checkpoints, and background image. It's a singleton entity (id=1) stored as JSON in the `field_properties` table. Templates provide presets for common field types (Football, Indoor). The field properties drive canvas rendering and coordinate calculations.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/global/classes/FieldProperties.ts` | Domain class, getters/setters |
+| `src/global/classes/FieldProperties.templates.ts` | Template definitions |
+| `src/global/classes/fieldTemplates/Football.ts` | Football field template |
+| `src/global/classes/fieldTemplates/Indoor.ts` | Indoor field template |
+| `src/hooks/queries/useFieldProperties.ts` | React Query hooks |
+| `src/components/field/FieldPropertiesSelector.tsx` | Template selector UI |
+| `src/components/field/FieldPropertiesCustomizer.tsx` | Customization editor |
+| `src/components/field/FieldPropertiesSettings.tsx` | Settings wrapper |
+| `src/components/field/FieldIoButtons.tsx` | Import/export buttons |
+| `src/components/field/fieldPropertiesSchema.ts` | Validation schema |
+| `src/components/field/customizer/GeneralTab.tsx` | General settings tab |
+| `src/components/field/customizer/CheckpointsTab.tsx` | Checkpoints tab |
+| `src/components/field/customizer/CheckpointEditor.tsx` | Single checkpoint editor |
+| `src/components/field/customizer/ImageTab.tsx` | Background image tab |
+| `src/components/field/customizer/ThemeTab.tsx` | Theme/colors tab |
+
+## Data Model
+
+Field properties are stored as a JSON blob in the `field_properties` table (singleton, id=1). The `FieldProperties` type comes from `@openmarch/core` and includes:
+
+- **Dimensions**: width, height in pixels; `pixelsPerStep` (key conversion factor)
+- **Grid**: yard line spacing, hash marks, grid visibility
+- **Theme**: colors for field, lines, sideline text
+- **Checkpoints**: named positions on the field (e.g., yard lines, hash marks) used for coordinate readouts
+- **Image**: optional background image URL and positioning
+
+## Key Concept: pixelsPerStep
+
+`pixelsPerStep` is the fundamental unit conversion:
+- 1 step = 22.5 inches (8-to-5 marching)
+- All canvas coordinates are in pixels
+- `pixelsPerStep` converts between canvas pixels and real-world distances
+- Used by `ReadableCoords`, `StepSize`, and `Prop` unit conversions
+
+## Query Pattern
+
+```typescript
+import { fieldPropertiesQueryOptions } from "@/hooks/queries";
+
+// Get field properties
+const { data: fieldProperties } = useQuery(fieldPropertiesQueryOptions());
+```
+
+Field properties are used everywhere (canvas rendering, coordinate display, prop sizing), so they're frequently queried.
+
+## Templates
+
+Templates provide preset field configurations:
+
+```typescript
+// Football field - standard NCAA/high school field
+import { footballField } from "@/global/classes/fieldTemplates/Football";
+
+// Indoor field - smaller rectangular area
+import { indoorField } from "@/global/classes/fieldTemplates/Indoor";
+```
+
+The `FieldPropertiesSelector` component lets users pick a template, then customize it with the `FieldPropertiesCustomizer`.
+
+## Customizer Tabs
+
+1. **GeneralTab** - Width, height, step size
+2. **CheckpointsTab** - Named positions (yard lines, hashes) with coordinates
+3. **ImageTab** - Background image upload and positioning
+4. **ThemeTab** - Field colors (background, lines, text)
+
+## Import/Export
+
+`FieldIoButtons` provides import/export of field configurations as JSON files, allowing users to share field setups.
+
+## Integration Points
+
+- **Canvas**: `OpenMarchCanvas.renderFieldGrid()` uses field properties for grid rendering
+- **Coordinates**: `ReadableCoords` converts pixel positions to human-readable field coordinates using checkpoints
+- **Props**: `getPixelsPerFoot()` in `Prop.ts` derives from `pixelsPerStep`
+- **Exporting**: Coordinate sheets use field properties for position labels
+- **Undo/redo**: `field_properties` table is tracked by history triggers
+
+## Gotchas
+
+- Field properties is a singleton - there's only one row (id=1).
+- Changing field properties can reposition everything. The canvas re-renders fully.
+- `pixelsPerStep` is the most critical value - it affects all coordinate calculations.
+- The `FieldProperties` type is imported from `@openmarch/core`, not defined locally.

--- a/.cursor/rules/ref-marchers.mdc
+++ b/.cursor/rules/ref-marchers.mdc
@@ -1,0 +1,146 @@
+---
+description: When working with marchers, sections, drill numbers, marcher CRUD, marcher list, or marcher canvas rendering
+alwaysApply: false
+---
+
+# Marchers Feature Reference
+
+## Overview
+
+Marchers are the core entity in OpenMarch - they represent performers on the field. Each marcher belongs to a section (instrument), has a drill number (e.g., "T1" for Trumpet 1), and has positions on each page via the `marcher_pages` junction table. Marchers are rendered on the canvas as `CanvasMarcher` objects.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/global/classes/Marcher.ts` | Domain class - sorting, drill number |
+| `src/global/classes/Sections.ts` | Section definitions (instruments) |
+| `src/global/classes/MarcherPage.ts` | Position per page (junction entity) |
+| `src/global/classes/MarcherPageIndex.ts` | Efficient lookup maps |
+| `src/global/classes/MarcherVisualGroup.ts` | Aggregates canvas visuals per marcher |
+| `src/global/classes/canvasObjects/CanvasMarcher.ts` | Fabric.js canvas object |
+| `src/db-functions/marcher.ts` | Database CRUD operations |
+| `src/db-functions/marcherPage.ts` | MarcherPage CRUD |
+| `src/hooks/queries/useMarchers.ts` | React Query hooks |
+| `src/hooks/queries/useMarcherPages.ts` | MarcherPage query hooks |
+| `src/hooks/queries/useMarchersWithVisuals.ts` | Combined marcher + visual data |
+| `src/components/marcher/MarcherList.tsx` | Marcher list UI |
+| `src/components/marcher/MarchersModal.tsx` | Sidebar modal wrapper |
+| `src/components/marcher/NewMarcherForm.tsx` | Create marcher form |
+
+## Data Model
+
+### Marcher (DatabaseMarcher)
+```typescript
+{
+    id: number;
+    name: string;           // Display name
+    section: string;        // Section name (e.g., "Trumpet")
+    drill_prefix: string;   // Section prefix (e.g., "T")
+    drill_order: number;    // Order within section (e.g., 1)
+    type: "marcher" | "prop"; // Entity type
+    notes: string | null;
+    created_at: string;
+    updated_at: string;
+}
+// Computed: drill_number = drill_prefix + drill_order (e.g., "T1")
+```
+
+### MarcherPage (DatabaseMarcherPage)
+```typescript
+{
+    id: number;
+    marcher_id: number;     // FK to marchers
+    page_id: number;        // FK to pages
+    x: number;              // X coordinate on field
+    y: number;              // Y coordinate on field
+    rotation_degrees: number | null;
+    // Appearance overrides (per-page)
+    fill_color: string | null;
+    outline_color: string | null;
+    shape_type: string | null;
+    visible: boolean;
+    label_visible: boolean;
+    equipment_name: string | null;
+    equipment_state: string | null;
+    // Path data
+    path_data_id: number | null;  // FK to pathways
+    path_start_position: number | null;
+    path_end_position: number | null;
+}
+```
+
+### Sections
+```typescript
+// src/global/classes/Sections.ts
+// Predefined sections with families:
+// Woodwind: Piccolo, Flute, Clarinet, Alto Sax, Tenor Sax, Bari Sax
+// Brass: Trumpet, Mellophone, Trombone, Baritone, Sousaphone
+// Battery: Snare, Tenors, Bass Drum, Cymbals
+// Guard: Color Guard, Dance Team, Twirler, Flag
+// Other: Drum Major
+// Each has: name, family, scoreOrder, prefix
+```
+
+## MarcherPageIndex
+
+Efficient lookup structure used across the app:
+
+```typescript
+// src/global/classes/MarcherPageIndex.ts
+class MarcherPageIndex {
+    marcherPagesByMarcher: Map<number, Map<number, MarcherPage>>;  // marcherId -> pageId -> MP
+    marcherPagesByPage: Map<number, Map<number, MarcherPage>>;     // pageId -> marcherId -> MP
+
+    static marcherPageMapFromArray(marcherPages: MarcherPage[]): MarcherPageIndex;
+    getByPageId(pageId: number): Map<number, MarcherPage>;
+    getByMarcherId(marcherId: number): Map<number, MarcherPage>;
+}
+```
+
+## Canvas Rendering
+
+`CanvasMarcher` extends `fabric.Group` and contains:
+- `dotObject` - the visual dot on the field
+- `textLabel` - drill number label
+- `appearances[]` - layered appearance settings
+- Methods: `setMarcherCoords()`, `getMarcherCoords()`, `setAppearance()`, `setNextAnimation()`
+
+`MarcherVisualGroup` aggregates per-marcher:
+- `canvasMarcher` - the CanvasMarcher instance
+- `previousPathway` / `nextPathway` - path visuals
+- `previousMidpoint` / `nextMidpoint` - midpoint markers
+- `previousEndPoint` / `nextEndPoint` - endpoint markers
+
+## Query Patterns
+
+```typescript
+// Get all marchers
+import { allMarchersQueryOptions } from "@/hooks/queries";
+const { data: marchers } = useQuery(allMarchersQueryOptions());
+
+// Create marchers
+import { createMarchersMutationOptions } from "@/hooks/queries";
+const createMutation = useMutation(createMarchersMutationOptions(queryClient));
+createMutation.mutate([{ name: "John", section: "Trumpet", drill_prefix: "T", drill_order: 1 }]);
+
+// Combined visual data
+import { useMarchersWithVisuals } from "@/hooks/queries";
+const { marchersWithVisuals, isLoading } = useMarchersWithVisuals();
+```
+
+## Integration Points
+
+- **MarcherPage**: Every marcher has a position on every page. Creating a marcher auto-creates MarcherPages for all existing pages.
+- **Tags**: Marchers can have tags (`marcher_tags` table) that affect their appearance.
+- **Shapes**: Marchers can be assigned to shapes (`shape_page_marchers`).
+- **Props**: A prop is linked to a marcher via `props.marcher_id` FK. Props use `type: "prop"` on the marcher.
+- **Canvas**: `CanvasMarcher` objects are managed by `OpenMarchCanvas.renderMarchers()`.
+- **Selection**: Selected marchers tracked via `SelectedMarchersContext`.
+
+## Gotchas
+
+- Marchers with `type: "prop"` are props, not regular marchers. Filter on `type` when listing.
+- `drill_number` is computed (prefix + order), not stored in DB.
+- When creating a marcher, MarcherPages for all existing pages are auto-created with default positions.
+- Marcher sorting uses `Marcher.compare()` which sorts by section score order, then drill order.

--- a/.cursor/rules/ref-pages-and-timing.mdc
+++ b/.cursor/rules/ref-pages-and-timing.mdc
@@ -1,0 +1,174 @@
+---
+description: When working with pages, beats, measures, timing, marcher pages, marcher positions, or the timing system
+alwaysApply: false
+---
+
+# Pages, Beats, Measures & Timing Reference
+
+## Overview
+
+Pages are the primary unit of drill - each page has a set number of counts and an order in the show. Beats are the fundamental timing unit; measures group beats. The `useTimingObjects` hook combines all three into a unified timeline used across the app.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/global/classes/Page.ts` | Page domain class with timing calculations |
+| `src/global/classes/Beat.ts` | Beat domain class with timestamp calculations |
+| `src/global/classes/Measure.ts` | Measure domain class containing beats |
+| `src/global/classes/MarcherPage.ts` | Marcher position on a page |
+| `src/global/classes/MarcherPageIndex.ts` | Efficient marcher-page lookup |
+| `src/global/classes/TimeSignature.ts` | Time signature handling |
+| `src/global/classes/BeatUnit.ts` | Beat unit calculations |
+| `src/db-functions/page.ts` | Page CRUD |
+| `src/db-functions/beat.ts` | Beat CRUD |
+| `src/db-functions/measures.ts` | Measure CRUD |
+| `src/db-functions/marcherPage.ts` | MarcherPage CRUD |
+| `src/hooks/queries/usePages.ts` | Page query hooks |
+| `src/hooks/queries/useBeats.ts` | Beat query hooks |
+| `src/hooks/queries/useMeasures.ts` | Measure query hooks |
+| `src/hooks/queries/useMarcherPages.ts` | MarcherPage query hooks |
+| `src/hooks/useTimingObjects.ts` | Combined timing data hook |
+| `src/context/SelectedPageContext.tsx` | Current page selection |
+
+## Data Model
+
+### Page
+```typescript
+{
+    id: number;
+    name: string;           // Display name (e.g., "2A")
+    counts: number;         // Duration in counts
+    order: number;          // Position in show
+    notes: string | null;
+    isSubset: boolean;      // True if subset of previous page
+    // Computed from beats:
+    duration: number;       // Duration in seconds
+    timestamp: number;      // Start time in seconds
+    nextPageId: number | null;
+    previousPageId: number | null;
+    beats: Beat[];          // Beats in this page
+    measures: Measure[];    // Measures in this page
+}
+```
+
+### Beat
+```typescript
+{
+    id: number;
+    position: number;       // Global beat position
+    duration: number;       // Duration in seconds (from BPM)
+    includeInMeasure: boolean;  // Whether this beat counts in measures
+    notes: string | null;
+    // Computed:
+    index: number;          // 0-based index
+    timestamp: number;      // Absolute time in seconds
+}
+```
+
+### Measure
+```typescript
+{
+    id: number;
+    startBeat: number;      // FK to beats.id
+    number: number;         // Measure number
+    rehearsalMark: string | null;
+    notes: string | null;
+    // Computed from contained beats:
+    duration: number;
+    counts: number;
+    timestamp: number;
+    beats: Beat[];
+}
+```
+
+## Timing System
+
+The timing system builds a unified timeline from beats, measures, and pages:
+
+```
+Beats (fundamental unit, each has duration from BPM)
+  ↓ grouped into
+Measures (musical grouping with time signatures)
+  ↓ referenced by
+Pages (drill pages, each starts at a specific beat)
+```
+
+### useTimingObjects Hook
+
+The primary hook for accessing the complete timeline:
+
+```typescript
+// src/hooks/useTimingObjects.ts
+import { useTimingObjects } from "@/hooks";
+
+const {
+    pages,          // Page[] - all pages with computed timing
+    measures,       // Measure[] - all measures with beats
+    beats,          // Beat[] - all beats with timestamps
+    isLoading,
+    hasError,
+} = useTimingObjects();
+```
+
+This is a multi-query hook that combines `usePages`, `useBeats`, `useMeasures`, and `useUtility` data. It calculates timestamps, durations, and links pages to their beats/measures.
+
+## Page Selection
+
+```typescript
+// src/context/SelectedPageContext.tsx
+import { useSelectedPage } from "@/context/SelectedPageContext";
+
+const { selectedPage, setSelectedPage, setPageToSelect } = useSelectedPage();
+
+// setSelectedPage({ id: pageId }) - select existing page
+// setPageToSelect({ id: pageId }) - select page after it's created (deferred)
+```
+
+## Page Operations
+
+Key operations in `src/db-functions/page.ts`:
+
+```typescript
+// Create pages
+createPagesInTransaction({ newPages, tx })
+
+// Update page counts
+updatePageCountInTransaction({ pageId, counts, tx })
+
+// Split a page
+splitPageInTransaction({ pageId, splitCount, tx })
+
+// Reorder pages (yank/push)
+yankOrPushPagesAfterIndexInTransaction({ startIndex, direction, tx })
+```
+
+When creating a page, MarcherPages are auto-created for all existing marchers with default positions.
+
+## Integration Points
+
+- **MarcherPage**: Junction between marchers and pages. Every (marcher, page) pair has coordinates.
+- **Canvas**: `OpenMarchCanvas` renders marchers at their MarcherPage positions for the selected page.
+- **Timeline**: `TimelineContainer` uses timing objects to display the visual timeline.
+- **Animation**: `useAnimation` interpolates marcher positions between pages during playback.
+- **Audio**: Beat timestamps sync with audio file playback.
+
+## Page 0 and transition times (critical)
+
+**Page 0 is a sentinel, not a real drill page.** In the DB it has `start_beat = 0` (beat 0). In `Page.fromDatabasePages()` (Page.ts) it is special-cased: `counts: 0`, `duration: 0`, `beats: [startBeat]`, `timestamp: 0`. Beat 0 typically has duration 0. So page 0 has **only one beat** and zero duration — it cannot define a transition. The first real drill page is page 1.
+
+**Transition duration is always the target page's duration.** There is no separate "transition time" column. So:
+- **0→1**: Page 0 has no duration (one beat, often 0s). The 0→1 transition time is **page 1's duration** (beats from page 1's `start_beat` up to page 2's `start_beat`). Not stored on page 0.
+- **N→(N+1)** for N≥1: **page (N+1)'s duration**.
+So the time from page 0 to 1 is not "between" two pages and not on page 0; it lives entirely as **page 1's duration**.
+
+**Formations are keyframed at the end of each page.** Keyframe time (ms) = `(page.timestamp + page.duration) * 1000`. So "play from page N" means: show formation at end of page N, then animate to end of page N+1 over page (N+1)'s duration. The animation for "getting to page N" is the segment ending at that keyframe; its duration is page N's duration.
+
+## Gotchas
+
+- Pages are ordered by `order` field, not `id`. Always sort by order.
+- Beat `position` is the global position (not relative to page). Timestamps are calculated cumulatively.
+- `Page.fromDatabasePages()` is the factory that enriches database rows with computed fields (duration, timestamp, beats, measures). It special-cases page 0 (FIRST_PAGE_ID).
+- Creating/deleting pages triggers MarcherPage creation/deletion for all marchers.
+- The `isSubset` field marks pages that are subsets of the previous page (used in display only).
+- Do not update page 0's `start_beat` or other non-notes fields; db-functions filter such changes (FIRST_PAGE_ID).

--- a/.cursor/rules/ref-props.mdc
+++ b/.cursor/rules/ref-props.mdc
@@ -1,0 +1,157 @@
+---
+description: When working with props, prop geometry, prop drawing, prop canvas rendering, or the props modal
+alwaysApply: false
+---
+
+# Props Feature Reference
+
+## Overview
+
+Props represent physical objects on the field (platforms, obstacles, floor markings). Each prop is linked to a marcher record (with `type: "prop"`) and has per-page geometry via the `prop_page_geometry` table. Props can be drawn on the canvas using various shape tools (rectangle, circle, arc, polygon, freehand).
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/global/classes/Prop.ts` | Types, constants, unit conversions |
+| `src/global/classes/PropVisualGroup.ts` | Aggregates visual elements per prop |
+| `src/global/classes/canvasObjects/CanvasProp.ts` | Fabric.js canvas object (extends CanvasMarcher) |
+| `src/db-functions/prop.ts` | Database CRUD operations |
+| `src/hooks/queries/useProps.ts` | React Query hooks |
+| `src/stores/PropDrawingStore.ts` | Drawing mode state |
+| `src/components/canvas/listeners/PropDrawingListeners.ts` | Canvas drawing event handlers |
+| `src/components/prop/PropList.tsx` | Prop list UI |
+| `src/components/prop/PropsModal.tsx` | Sidebar modal wrapper |
+| `src/components/prop/PropEditForm.tsx` | Edit prop form |
+| `src/components/prop/NewPropForm.tsx` | Create prop form |
+| `src/components/prop/PropToolSelector.tsx` | Drawing tool selector |
+
+## Data Model
+
+### Props Table
+```typescript
+type DatabaseProp = {
+    id: number;
+    marcher_id: number;         // FK to marchers (type="prop")
+    surface_type: SurfaceType;  // "floor" | "platform" | "obstacle"
+    asset_url: string | null;
+    prop_category: string | null;
+    default_width: number;      // Default width in pixels
+    default_height: number;     // Default height in pixels
+    created_at: string;
+    updated_at: string;
+};
+
+type PropWithMarcher = DatabaseProp & {
+    marcher: typeof schema.marchers.$inferSelect;
+};
+```
+
+### Prop Page Geometry
+```typescript
+type DatabasePropPageGeometry = {
+    id: number;
+    marcher_page_id: number;    // FK to marcher_pages, unique
+    outline_type: OutlineType;  // NOT "shape" — see naming note below
+    width: number;              // feet, CHECK width > 0
+    height: number;             // feet, CHECK height > 0
+    custom_outline: string | null;  // JSON point list for arc/polygon/freehand
+    rotation: number;           // degrees, defaults to 0
+};
+
+type OutlineType = "rectangle" | "circle" | "arc" | "polygon" | "freehand";
+```
+
+**Naming**: a prop's silhouette is its **outline**, never its "shape". "Shape"
+means a drill formation (`shapes` / `shape_pages` / `shape_page_marchers`).
+See `apps/desktop/CONTEXT.md` for the full glossary.
+
+**Which fields animate**: `width`, `height` and `rotation` interpolate between
+pages (the `PropTransform` type). `outline_type` and `custom_outline` are
+discrete and snap at the page boundary.
+
+### Surface Types
+```typescript
+type SurfaceType = "floor" | "platform" | "obstacle";
+```
+
+Recorded and displayed, but carries **no runtime behavior** — nothing renders,
+stacks, or collides differently because of it. The `SURFACE_TYPE_Z_ORDER` map is
+commented out in `Prop.ts` until 3D makes it meaningful.
+
+### Drawing Modes
+```typescript
+type PropDrawingMode = "rectangle" | "circle" | "arc" | "polygon" | "freehand" | null;
+```
+
+## Unit Conversions
+
+Props use real-world feet for dimensions, converted to canvas pixels:
+
+```typescript
+import { getPixelsPerFoot } from "@/global/classes/Prop";
+
+const pixelsPerFoot = getPixelsPerFoot();
+const widthPx = 10 * pixelsPerFoot; // 10 feet -> pixels
+const widthFt = 150 / pixelsPerFoot; // 150 pixels -> feet
+```
+
+Default prop size: `DEFAULT_PROP_WIDTH = 15`, `DEFAULT_PROP_HEIGHT = 15` (pixels).
+
+## Canvas Rendering
+
+`CanvasProp` extends `CanvasMarcher` and adds:
+- `propId` - the prop's database id
+- `propObj` - the DatabaseProp data
+- `geometry` - the DatabasePropPageGeometry for current page
+- `shapeObject` - Fabric.js shape (rect, circle, or custom path)
+- Methods: `getDimensions()`, `getEdges()`, `setEdges()`
+
+`PropVisualGroup` is similar to `MarcherVisualGroup` but without the `canvasMarcher` property - it only has pathway/midpoint/endpoint visuals.
+
+## Drawing Store
+
+```typescript
+import { usePropDrawingStore } from "@/stores/PropDrawingStore";
+
+const {
+    drawingMode,      // Current tool: "rectangle" | "circle" | ... | null
+    isDrawing,        // Currently drawing
+    startPoint,       // Initial click point
+    points,           // Accumulated points (polygon/freehand)
+    setDrawingMode,   // Activate a drawing tool
+    resetDrawingState // Clear all drawing state
+} = usePropDrawingStore();
+```
+
+## Architecture: Prop-Marcher Relationship
+
+Props piggyback on the marcher system:
+1. Creating a prop also creates a marcher record with `type: "prop"`
+2. This marcher gets MarcherPages (positions) on every page
+3. `prop_page_geometry` stores the shape/size per page via `marcher_page_id` FK
+4. On canvas, `CanvasProp` extends `CanvasMarcher` to reuse positioning logic
+
+This means props participate in undo/redo, pathways, and animation just like marchers.
+
+## Integration Points
+
+- **Marcher system**: Props create a marcher with `type: "prop"`. The marcher_pages provide positioning.
+- **Canvas**: `PropDrawingListeners.ts` handles mouse events for drawing. `CanvasProp` renders on canvas.
+- **PropDrawingStore**: Zustand store tracks active drawing tool and state.
+- **Field Properties**: Unit conversions depend on `fieldProperties.pixelsPerStep`.
+
+## Gotchas
+
+- A prop always has a backing marcher with `type: "prop"`. Deleting the marcher deletes the prop.
+- There is no per-page visibility column. Hiding a prop is a display preference held in
+  `UiSettingsStore.hiddenPropIds`, not part of the show — a prop is on the field on every page.
+- `prop_page_geometry` IS tracked by undo/redo history triggers — it is listed in
+  `tablesWithHistory`. Any write path that touches it must use `transactionWithHistory`, not a plain
+  transaction, so that all the rows one user action writes undo as a single step. See ADR-0001.
+- `custom_outline` stores a JSON point list (`{ points, originalWidth, originalHeight, closed }`),
+  not SVG path data. Only arc, polygon and freehand use it.
+- Rendering a prop onto any canvas goes through `addPropsToCanvas` in
+  `canvasObjects/renderProps.ts` — the interactive canvas, SVG export and video export all use it.
+  Don't construct a `CanvasProp` directly.
+- The `PropDrawingListeners` are only active when `drawingMode` is non-null in the PropDrawingStore.

--- a/.cursor/rules/ref-shapes.mdc
+++ b/.cursor/rules/ref-shapes.mdc
@@ -1,0 +1,131 @@
+---
+description: When working with shapes, formations, shape pages, SVG paths, editable paths, or the shape editor
+alwaysApply: false
+---
+
+# Shapes & Formations Reference
+
+## Overview
+
+Shapes represent formation outlines that marchers can be assigned to. A shape exists across pages via `shape_pages` (each with its own SVG path), and marchers are placed along shapes via `shape_page_marchers`. Shapes are rendered on the canvas as `MarcherShape` objects and can be edited with control points.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| **Domain Classes** | |
+| `src/global/classes/canvasObjects/MarcherShape.ts` | Shape rendering on canvas |
+| `src/global/classes/canvasObjects/ShapePath.ts` | SVG path for shape outline |
+| `src/global/classes/canvasObjects/ShapePoint.ts` | Point along a shape |
+| `src/global/classes/canvasObjects/ShapePointController.ts` | Control point handles |
+| `src/global/classes/canvasObjects/StaticMarcherShape.ts` | Non-editable shape rendering |
+| `src/global/classes/canvasObjects/SvgCommand.ts` | SVG command parsing |
+| `src/global/classes/canvasObjects/EditablePath.ts` | Editable path with control points |
+| **Database** | |
+| `src/db-functions/shapes.ts` | Shape CRUD |
+| `src/db-functions/shapePages.ts` | ShapePage CRUD |
+| `src/db-functions/shapePageMarchers.ts` | ShapePageMarcher CRUD |
+| `src/hooks/queries/useShapePages.ts` | React Query hooks |
+| **UI** | |
+| `src/components/inspector/ShapeEditor.tsx` | Shape editing panel |
+| `src/components/inspector/ShapeSelector.tsx` | Shape selection dropdown |
+| `src/components/canvas/hooks/editablePath.tsx` | Editable path React hook |
+| `src/components/canvas/hooks/shapes.ts` | Shape rendering hook |
+| **Store** | |
+| `src/stores/SelectionStore.ts` | Selected shape page IDs |
+
+## Data Model
+
+### Shapes Table
+```typescript
+{
+    id: number;
+    name: string;           // Display name
+    created_at: string;
+    updated_at: string;
+}
+```
+
+### Shape Pages Table
+```typescript
+{
+    id: number;
+    shape_id: number;       // FK to shapes
+    page_id: number;        // FK to pages
+    svg_path: string;       // SVG path data (e.g., "M 0 0 L 100 0 L 100 100")
+    notes: string | null;
+    created_at: string;
+    updated_at: string;
+}
+```
+
+### Shape Page Marchers Table
+```typescript
+{
+    id: number;
+    shape_page_id: number;  // FK to shape_pages
+    marcher_id: number;     // FK to marchers
+    position_order: number; // Order along the shape path
+    created_at: string;
+    updated_at: string;
+}
+```
+
+## SVG Path System
+
+Shapes use SVG path commands to define their outline:
+
+```typescript
+// src/global/classes/canvasObjects/SvgCommand.ts
+// Supported SVG commands:
+// M x y        - Move to
+// L x y        - Line to
+// C x1 y1 x2 y2 x y  - Cubic bezier
+// Q x1 y1 x y - Quadratic bezier
+// Z            - Close path
+```
+
+`ShapePath` parses the SVG string into `SvgCommand` objects for rendering and manipulation.
+
+## Canvas Objects
+
+### MarcherShape
+The main canvas representation of a shape:
+- Renders the SVG path outline
+- Places `ShapePoint` markers where marchers are positioned along the path
+- `ShapePointController` handles provide drag controls for editing
+- Connected to `EditablePath` for interactive editing
+
+### EditablePath
+Interactive path editing system:
+- `ControlPoint` - Bezier curve control handles
+- Users can add/remove/move control points
+- Changes update the `svg_path` in the database
+
+### StaticMarcherShape
+Read-only rendering of shapes (used during animation/playback).
+
+## Shape Editing Flow
+
+1. User selects a shape via `ShapeSelector` in Inspector
+2. `ShapeEditor` shows shape properties and marcher assignments
+3. On canvas, shape becomes editable with `EditablePath`
+4. User drags control points → updates SVG path
+5. On save, `svg_path` is updated in `shape_pages` table
+6. Marchers snap to positions along the updated path
+
+## Integration Points
+
+- **Marchers**: Marchers are assigned to shapes via `shape_page_marchers`. Their positions are calculated along the SVG path based on `position_order`.
+- **Pages**: Each shape can have different paths on different pages (via `shape_pages`).
+- **Canvas**: Shapes are rendered after marchers in the pipeline. Selected shapes tracked in `SelectionStore`.
+- **Inspector**: `ShapeEditor` and `ShapeSelector` provide the editing UI.
+- **Undo/redo**: `shapes`, `shape_pages`, and `shape_page_marchers` are all tracked by history triggers.
+
+## Gotchas
+
+- A shape must have a `shape_pages` entry for a page to be visible on that page.
+- Marcher positions on shapes are relative to the SVG path, not absolute coordinates.
+- The `position_order` in `shape_page_marchers` determines spacing along the path.
+- Editing a shape path recalculates all marcher positions along it.
+- SVG path parsing is custom (not a browser SVG renderer) - see `SvgCommand.ts`.

--- a/.cursor/rules/ref-state-management.mdc
+++ b/.cursor/rules/ref-state-management.mdc
@@ -1,0 +1,213 @@
+---
+description: When working with Zustand stores, React Context providers, React Query patterns, or deciding where to put state
+alwaysApply: false
+---
+
+# State Management Reference
+
+## Overview
+
+OpenMarch uses three state management approaches, each for a specific category: React Query for server/database state, Zustand for UI state, and React Context for component tree state. Understanding which to use is critical for maintaining consistency.
+
+## Decision Guide
+
+| Category | Tool | When to Use |
+|----------|------|-------------|
+| Database/server data | React Query | Any data from the database (marchers, pages, shapes, etc.) |
+| UI-only state | Zustand | Canvas state, drawing mode, modal open/close, settings |
+| Component tree state | React Context | Selected page, selected marchers, playback state, theme |
+
+**Rule of thumb**: If it comes from the database, use React Query. If it's UI state shared across unrelated components, use Zustand. If it flows down the component tree and is set by parents/consumed by children, use Context.
+
+## Zustand Stores
+
+All stores are in `src/stores/`:
+
+### CanvasStore
+```typescript
+// Canvas instance and viewport (zoom, pan)
+import { useCanvasStore } from "@/stores/CanvasStore";
+const { canvas, viewport, setCanvas, zoomToFit, resetViewport } = useCanvasStore();
+```
+
+### SelectionStore
+```typescript
+// Selected shape page IDs
+import { useSelectionStore } from "@/stores/SelectionStore";
+```
+
+### UiSettingsStore
+```typescript
+// UI preferences (persisted to localStorage)
+import { useUiSettingsStore } from "@/stores/UiSettingsStore";
+const { lockX, lockY, gridLines, collisions, pixelsPerSecond, audioVolume, mouseSettings, focussedComponent } = useUiSettingsStore();
+```
+
+### SidebarModalStore
+```typescript
+// Sidebar modal open state and content
+import { useSidebarModalStore } from "@/stores/SidebarModalStore";
+const { isOpen, content, contentId, toggleOpen, setContent } = useSidebarModalStore();
+```
+
+### PropDrawingStore
+```typescript
+// Prop drawing state (mode, points, etc.)
+import { usePropDrawingStore } from "@/stores/PropDrawingStore";
+const { drawingMode, isDrawing, startPoint, points, setDrawingMode, resetDrawingState } = usePropDrawingStore();
+```
+
+### RegisteredActionsStore
+```typescript
+// Links button refs to keyboard shortcuts
+import { useRegisteredActionsStore } from "@/stores/RegisteredActionsStore";
+const { linkRegisteredAction, removeRegisteredAction } = useRegisteredActionsStore();
+```
+
+### MetronomeStore
+```typescript
+// Metronome settings
+import { useMetronomeStore } from "@/stores/MetronomeStore";
+const { metronomeOn, accentOn, volume, beatStyle, toggleMetronome } = useMetronomeStore();
+```
+
+### AlignmentEventStore
+```typescript
+// Alignment tool state (default, line, lasso)
+import { useAlignmentEventStore } from "@/stores/AlignmentEventStore";
+const { alignmentEvent, setAlignmentEvent, resetAlignmentEvent } = useAlignmentEventStore();
+```
+
+### CollisionStore
+```typescript
+// Collision data per page
+import { useCollisionStore } from "@/stores/CollisionStore";
+const { collisions, currentCollision, setCollisions } = useCollisionStore();
+```
+
+### FullscreenStore
+```typescript
+// Fullscreen mode
+import { useFullscreenStore } from "@/stores/FullscreenStore";
+const { isFullscreen, perspective, toggleFullscreen, setPerspective } = useFullscreenStore();
+```
+
+## React Context Providers
+
+All in `src/context/`:
+
+### SelectedPageContext
+```typescript
+import { useSelectedPage } from "@/context/SelectedPageContext";
+const { selectedPage, setSelectedPage, setPageToSelect } = useSelectedPage();
+// setPageToSelect is for deferred selection (page not yet created)
+```
+
+### SelectedMarchersContext
+```typescript
+import { useSelectedMarchers } from "@/context/SelectedMarchersContext";
+// Automatically filters out hidden marchers (visible=false in appearances)
+```
+
+### IsPlayingContext
+```typescript
+import { useIsPlaying } from "@/context/IsPlayingContext";
+const { isPlaying, setIsPlaying } = useIsPlaying();
+```
+
+### SelectedAudioFileContext
+```typescript
+import { useSelectedAudioFile } from "@/context/SelectedAudioFileContext";
+```
+
+### ThemeContext
+```typescript
+import { useTheme } from "@/context/ThemeContext";
+// Syncs with Electron store and system preferences
+```
+
+## React Query Patterns
+
+### Query Key Factories
+
+Every entity uses a key factory pattern:
+
+```typescript
+const KEY_BASE = "marchers";
+
+export const marcherKeys = {
+    all: () => [KEY_BASE] as const,
+    byId: (id: number) => [KEY_BASE, "id", id] as const,
+};
+```
+
+### Query Options
+
+```typescript
+import { queryOptions } from "@tanstack/react-query";
+
+export const allMarchersQueryOptions = () =>
+    queryOptions({
+        queryKey: marcherKeys.all(),
+        queryFn: async () => getMarchers({ db }),
+    });
+```
+
+### Mutation Options
+
+```typescript
+import { mutationOptions, QueryClient } from "@tanstack/react-query";
+
+export const createMarchersMutationOptions = (qc: QueryClient) =>
+    mutationOptions({
+        mutationFn: (newMarchers) => createMarchers({ db, newMarchers }),
+        onSuccess: () => {
+            void qc.invalidateQueries({ queryKey: [KEY_BASE] });
+        },
+        onError: (e, variables) => {
+            conToastError("Error creating marchers", e, variables);
+        },
+    });
+```
+
+### Cache Invalidation
+
+After mutations, invalidate related queries:
+
+```typescript
+// Invalidate all queries for an entity
+void qc.invalidateQueries({ queryKey: [KEY_BASE] });
+
+// Shared invalidators for cross-entity invalidation
+// See src/hooks/queries/sharedInvalidators.ts
+```
+
+### Multi-Query Hooks
+
+For combining data from multiple queries, use `useQueries` with a stable `combine` function:
+
+```typescript
+export const useTimingObjects = () =>
+    useQueries({
+        queries: [pagesQuery, beatsQuery, measuresQuery, utilityQuery],
+        combine: _combineTimingObjects,  // Stable reference, NOT inline
+    });
+```
+
+See the `multi-query-hooks.mdc` cursor rule for the full pattern.
+
+## StateInitializer
+
+`src/components/singletons/StateInitializer.tsx` runs on mount:
+- Prefetches queries for current and adjacent pages
+- Selects the first page if none selected
+- Loads the selected audio file
+- Sets up initial state for stores
+
+## Gotchas
+
+- Zustand stores are singletons. Use `useStore()` hook in components, `useStore.getState()` outside React.
+- React Query's `queryClient` is created in `App.tsx` and exported. Pass it to mutation options.
+- Never use inline `combine` functions in `useQueries` - causes re-renders every cycle.
+- UiSettingsStore persists to localStorage. Changes survive page reloads.
+- SelectedMarchersContext auto-filters hidden marchers. This can cause confusion if a "selected" marcher disappears.

--- a/.cursor/rules/ref-tags-and-appearances.mdc
+++ b/.cursor/rules/ref-tags-and-appearances.mdc
@@ -1,0 +1,164 @@
+---
+description: When working with tags, appearances, section appearances, marcher appearances, visual styling, or tag management
+alwaysApply: false
+---
+
+# Tags & Visual Appearances Reference
+
+## Overview
+
+The appearance system controls how marchers look on the canvas (color, shape, visibility, label). Appearances are resolved in layers: section defaults -> tag overrides -> per-marcher-page overrides. Tags are user-defined groups that can apply appearance overrides to their members on specific pages.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| **Database** | |
+| `src/db-functions/tag.ts` | Tag CRUD, marcher-tag assignments, tag appearances |
+| `src/db-functions/sectionAppearance.ts` | Section appearance CRUD |
+| **Query Hooks** | |
+| `src/hooks/queries/useMarcherAppearances.ts` | Resolved appearance per marcher |
+| `src/hooks/queries/useSectionAppearances.ts` | Section appearance hooks |
+| `src/hooks/queries/tags/queries.ts` | Tag query hooks |
+| `src/hooks/queries/tags/mutations.ts` | Tag mutation hooks |
+| **Components** | |
+| `src/components/marcher/appearance/AppearanceEditor.tsx` | Main appearance editor |
+| `src/components/marcher/appearance/AppearanceModal.tsx` | Sidebar modal |
+| `src/components/marcher/appearance/SectionAppearanceList.tsx` | Section defaults list |
+| `src/components/marcher/appearance/TagAppearanceList.tsx` | Tag overrides list |
+| `src/components/tags/TagsModel.tsx` | Tag management modal |
+| `src/entity-components/appearance.ts` | Appearance type definitions |
+
+## Data Model
+
+### Section Appearances
+```typescript
+{
+    id: number;
+    section: string;        // Section name (e.g., "Trumpet")
+    // Appearance fields:
+    fill_color: string | null;
+    outline_color: string | null;
+    shape_type: string | null;
+    visible: boolean;
+    label_visible: boolean;
+    equipment_name: string | null;
+    equipment_state: string | null;
+}
+```
+
+### Tags
+```typescript
+{
+    id: number;
+    name: string;
+    color: string | null;   // Tag color for UI display
+    notes: string | null;
+}
+```
+
+### Marcher Tags (junction)
+```typescript
+{
+    id: number;
+    marcher_id: number;     // FK to marchers
+    tag_id: number;         // FK to tags
+}
+```
+
+### Tag Appearances (per page)
+```typescript
+{
+    id: number;
+    tag_id: number;         // FK to tags
+    page_id: number;        // FK to pages
+    priority: number;       // Higher = takes precedence
+    // Same appearance fields as section_appearances
+    fill_color: string | null;
+    outline_color: string | null;
+    shape_type: string | null;
+    visible: boolean;
+    label_visible: boolean;
+    equipment_name: string | null;
+    equipment_state: string | null;
+}
+```
+
+## Appearance Resolution Order
+
+Appearances are resolved bottom-up, with later layers overriding earlier ones:
+
+```
+1. Section Appearance (base defaults for all marchers in a section)
+   ↓ overridden by
+2. Tag Appearances (per-page overrides, sorted by priority DESC)
+   ↓ overridden by
+3. MarcherPage Overrides (per-marcher, per-page direct overrides)
+```
+
+Each layer only overrides non-null fields. Null fields fall through to the previous layer.
+
+## Resolved Appearances Hook
+
+```typescript
+import { marcherAppearancesByPageQueryOptions } from "@/hooks/queries";
+
+// Returns Record<marcherId, AppearanceComponentOptional[]>
+// Each marcher has an ordered array of appearance layers
+const { data: appearances } = useQuery(
+    marcherAppearancesByPageQueryOptions(pageId)
+);
+```
+
+The resolution logic in `useMarcherAppearances.ts`:
+1. Fetches section appearances, tag appearances for the page, marcher-tag assignments, and marcher pages
+2. For each marcher: builds an array starting with section appearance, then tag appearances (sorted by priority), then marcher page overrides
+3. `CanvasMarcher.setAppearance()` merges these layers to determine final visual
+
+## AppearanceComponentOptional Type
+
+```typescript
+type AppearanceComponentOptional = {
+    fill_color?: string | null;
+    outline_color?: string | null;
+    shape_type?: string | null;
+    visible?: boolean;
+    label_visible?: boolean;
+    equipment_name?: string | null;
+    equipment_state?: string | null;
+};
+```
+
+## Tag Operations
+
+```typescript
+// Create tag
+createTagsInTransaction({ newTags: [{ name: "Soloist", color: "#ff0000" }], tx })
+
+// Assign marcher to tag
+createMarcherTagsInTransaction({ newMarcherTags: [{ marcher_id: 1, tag_id: 1 }], tx })
+
+// Create tag appearance for a page
+createTagAppearancesInTransaction({
+    newTagAppearances: [{
+        tag_id: 1, page_id: 1, priority: 10,
+        fill_color: "#ff0000", visible: true
+    }],
+    tx
+})
+```
+
+## Integration Points
+
+- **Canvas**: `CanvasMarcher` receives resolved appearances and applies them (color, visibility, shape).
+- **Selection**: `SelectedMarchersContext` filters out hidden marchers based on appearance `visible` field.
+- **Inspector**: `MarcherEditor` shows per-marcher-page appearance overrides.
+- **Undo/redo**: All appearance tables (`section_appearances`, `tags`, `tag_appearances`, `marcher_tags`) are tracked by history triggers.
+
+## Gotchas
+
+- Tag appearances are per-page. A tag can have different visual overrides on different pages.
+- `priority` on tag appearances determines override order. Higher priority wins.
+- When multiple tags apply to the same marcher, they're layered by priority (highest on top).
+- Null fields in an appearance layer mean "don't override" - they pass through to the layer below.
+- `visible: false` on any layer hides the marcher. The selection context respects this.

--- a/.cursor/rules/ref-timeline-and-audio.mdc
+++ b/.cursor/rules/ref-timeline-and-audio.mdc
@@ -1,0 +1,148 @@
+---
+description: When working with the timeline, audio playback, animation, metronome, MusicXML import, or waveform display
+alwaysApply: false
+---
+
+# Timeline, Audio & Animation Reference
+
+## Overview
+
+The timeline system handles audio playback, beat/measure visualization, and canvas animation. The `TimelineContainer` at the bottom of the workspace shows pages, audio waveforms, and timing markers. During playback, `useAnimation` interpolates marcher positions between pages and drives the canvas.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| **Timeline Components** | |
+| `src/components/timeline/TimelineContainer.tsx` | Main timeline wrapper |
+| `src/components/timeline/PageTimeline.tsx` | Visual page timeline |
+| `src/components/timeline/PageTimeline.utils.ts` | Timeline utility functions |
+| `src/components/timeline/TimelineControls.tsx` | Play/pause/stop controls |
+| `src/components/timeline/PerspectiveSlider.tsx` | 3D perspective control |
+| **Audio Components** | |
+| `src/components/timeline/audio/AudioPlayer.tsx` | Read-only audio player |
+| `src/components/timeline/audio/EditableAudioPlayer.tsx` | Editable audio player |
+| `src/components/timeline/audio/EditableBeatAudioPlayer.tsx` | Beat-synced editable player |
+| `src/components/timeline/audio/WaveformTimingOverlay.tsx` | Waveform overlay |
+| `src/components/timeline/audio/TimingMarkersPlugin.ts` | Beat markers on waveform |
+| `src/components/timeline/audio/EditableTimingMarkersPlugin.ts` | Editable beat markers |
+| `src/components/timeline/audio/volume.ts` | Volume utilities |
+| **Music Components** | |
+| `src/components/music/MusicModal.tsx` | Music settings modal |
+| `src/components/music/AudioSelector.tsx` | Audio file selector |
+| `src/components/music/MetronomeModal.tsx` | Metronome settings |
+| `src/components/music/MusicXmlSelector.tsx` | MusicXML file selector |
+| `src/components/music/MusicXmlImport.ts` | MusicXML parser |
+| `src/components/music/TempoGroup/` | Tempo group management |
+| **Domain & Hooks** | |
+| `src/global/classes/AudioFile.ts` | Audio file domain class |
+| `src/global/classes/TimeSignature.ts` | Time signature handling |
+| `src/global/classes/BeatUnit.ts` | Beat unit calculations |
+| `src/hooks/useAnimation.ts` | Canvas animation during playback |
+| `src/hooks/useTimingObjects.ts` | Combined timing data |
+| **Stores & Context** | |
+| `src/stores/MetronomeStore.ts` | Metronome state |
+| `src/context/IsPlayingContext.tsx` | Playback state |
+| `src/context/SelectedAudioFileContext.tsx` | Current audio file |
+
+## Animation System
+
+`useAnimation` is the core playback hook:
+
+```typescript
+// src/hooks/useAnimation.ts
+// Called in Canvas.tsx, drives playback:
+// 1. When isPlaying becomes true, starts requestAnimationFrame loop
+// 2. Each frame: calculates current time position from audio
+// 3. Determines which page (and position within page) we're at
+// 4. Interpolates marcher positions between current and next page
+// 5. Calls canvas.setMarcherCoords() with interpolated positions
+// 6. When playback stops, snaps marchers to nearest page position
+```
+
+Key concepts:
+- Interpolation is linear between MarcherPage positions
+- Beat timestamps determine page boundaries
+- Pathways (if defined) override linear interpolation with curved paths
+- Animation respects the current audio playback position
+
+## Audio File System
+
+```typescript
+// src/global/classes/AudioFile.ts
+type AudioFile = {
+    id: number;
+    path: string;           // File path
+    nickname: string;       // Display name
+    data: ArrayBuffer;      // Audio data
+    selected: boolean;      // Is this the active audio file
+};
+
+// Static methods:
+AudioFile.getSelectedAudioFile()
+AudioFile.setSelectedAudioFile(id)
+AudioFile.deleteAudioFile(id)
+```
+
+Audio files are managed via Electron IPC (file system access in main process), not the SQLite DB functions pattern.
+
+## Timeline Layout
+
+```
+TimelineContainer
+├── TimelineControls (play/pause/stop/fullscreen)
+├── PerspectiveSlider (3D view control)
+├── PageTimeline (visual page blocks with counts)
+└── AudioPlayer / EditableAudioPlayer
+    └── WaveformTimingOverlay
+        └── TimingMarkersPlugin (beat/measure markers)
+```
+
+## MusicXML Import
+
+`MusicXmlImport.ts` parses MusicXML files to extract:
+- Time signatures
+- Tempo markings (BPM)
+- Rehearsal marks
+- Measure boundaries
+
+These are converted to beats and measures in the database.
+
+## Tempo Groups
+
+Tempo groups (`src/components/music/TempoGroup/`) manage BPM changes:
+- Each group has a start beat, BPM, and time signature
+- Beat durations are calculated from BPM
+- Groups can be edited, created, deleted
+
+## Metronome
+
+```typescript
+import { useMetronomeStore } from "@/stores/MetronomeStore";
+
+const {
+    metronomeOn,    // Is metronome active
+    accentOn,       // Accent on downbeats
+    volume,         // Metronome volume (0-1)
+    beatStyle,      // Click sound style
+    toggleMetronome,
+    setVolume,
+} = useMetronomeStore();
+```
+
+The metronome plays clicks synced to beat timestamps during playback.
+
+## Integration Points
+
+- **Canvas**: `useAnimation` drives canvas marcher positions during playback
+- **Timing**: `useTimingObjects` provides the unified timeline data
+- **Context**: `IsPlayingContext` tracks play/pause state, `SelectedAudioFileContext` tracks current audio
+- **UiSettings**: `pixelsPerSecond` in `UiSettingsStore` controls timeline zoom level
+
+## Gotchas
+
+- Audio files are stored on disk, referenced by path. Moving the file breaks the reference.
+- The animation loop uses `requestAnimationFrame` - it's tied to the browser's refresh rate.
+- Interpolation between pages assumes beats have timestamps. Missing timestamps break animation.
+- The timeline UI width depends on `pixelsPerSecond` from `UiSettingsStore`.
+- MusicXML import creates beats/measures in a single transaction. Importing over existing data replaces it.

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -66,6 +66,7 @@ words:
   - idioma
   - importmap
   - Invalidators
+  - keyframed
   - launchpage
   - lightridge
   - localappdata
@@ -77,6 +78,7 @@ words:
   - mello
   - merch
   - Meuli
+  - mgmt
   - midset
   - midsets
   - monokai
@@ -116,6 +118,7 @@ words:
   - rwxr
   - saario
   - samuelmeuli
+  - sandboxing
   - Schachner
   - Segoe
   - seti
@@ -179,6 +182,7 @@ words:
   - youtu
   - zier
   - Zingali
+  - Zustand
   - 日本語
 ignorePaths:
   - node_modules/**


### PR DESCRIPTION
Fourteen reference files under `.cursor/rules/` that give IDE agents context on this codebase: the architecture, the database layer, the canvas, exporting, state management, localization, and the individual domains (marchers, pages and timing, shapes, props, tags and appearances, timeline and audio, field properties, the electron layer).

These were sitting inside the props branch, where they didn't belong and accounted for about 2,000 lines of its diff. Merging this first keeps them out of that review.

`ref-props.mdc` is included at its corrected state. The props work renamed `shape_type` to `outline_type` and `custom_geometry` to `custom_outline`, dropped the per-page `visible` column, and established that `prop_page_geometry` is undo-tracked. The file documents the schema as it now stands rather than as it was first drafted.

No code changes. `cspell.config.yaml` picks up four words the rule files use: keyframed, mgmt, sandboxing, Zustand.
