### PR TITLE
fix: stop metronome toggle from restarting playback and stacking ticks (#997)

### DIFF
--- a/apps/desktop/src/components/timeline/audio/AudioPlayer.tsx
+++ b/apps/desktop/src/components/timeline/audio/AudioPlayer.tsx
@@ -400,9 +400,12 @@ export default function AudioPlayer() {
             const metroSource = audioContext.createBufferSource();
             metroGainNode.current = audioContext.createGain();
             const masterVolume = calculateMasterVolume(audioVolume, audioMuted);
+            // Read metronome settings at playback start, live changes update gain below without restarting
+            const { isMetronomeOn: metronomeOn, volume: metronomeVolume } =
+                useMetronomeStore.getState();
             metroGainNode.current.gain.value =
-                isMetronomeOn && masterVolume > 0
-                    ? volumeAdjustment(volume) * masterVolume
+                metronomeOn && masterVolume > 0
+                    ? volumeAdjustment(metronomeVolume) * masterVolume
                     : 0;
             metroSource.buffer = metronomeBuffer;
             metroSource
@@ -412,11 +415,12 @@ export default function AudioPlayer() {
             audioSource.start(startAt, playbackTimestamp);
             metroSource.start(startAt, playbackTimestamp);
 
+            // Only clear the ref if it still points at this source, a restart may have replaced it
             audioSource.onended = () => {
-                audioNode.current = null;
+                if (audioNode.current === audioSource) audioNode.current = null;
             };
             metroSource.onended = () => {
-                metroNode.current = null;
+                if (metroNode.current === metroSource) metroNode.current = null;
             };
 
             audioNode.current = audioSource;
@@ -449,8 +453,6 @@ export default function AudioPlayer() {
         playbackTimestamp,
         audioVolume,
         audioMuted,
-        isMetronomeOn,
-        volume,
     ]);
 
     // Initialize WaveSurfer and load waveform data


### PR DESCRIPTION
## Summary

Fixes #997. Toggling the metronome while a show is playing caused playback to restart/jump and the metronome ticks to stack into overlapping, looping audio.

## Changes

  - Read metronome on/off and volume via `useMetronomeStore.getState()` at playback start, and remove them from the play/pause effect's dependency array. Live changes are already handled by the existing gain-only effect, so toggling now just mutes/unmutes without restarting playback.
  - Guard both `onended` handlers to clear the ref only when it still points at that same source, preventing a replaced source from nulling the current one.
  
  ## Files changed

  - `apps/desktop/src/components/timeline/audio/AudioPlayer.tsx`

  ## Manual testing

  1. Load a show with audio and beats/measures.
  2. Press Play. While playing, click the timeline metronome button on/off several times rapidly.
     - Expected: ticks fade in/out instantly, audio keeps playing continuously with no jump-back, and no stacking/overlapping ticks.
  3. With the metronome on and playing, drag the metronome volume slider in the modal.
     - Expected: tick volume changes smoothly, playback does not restart.
  4. Start playback with the metronome already on, then again with it off.
     - Expected: initial tick state is correct in both cases.
  5. Toggle the metronome via its keyboard shortcut mid-playback.
     - Expected: same clean behavior, no restart or overlap.
  6. Adjust the master volume slider mid-playback with the metronome on.
     - Expected: no overlapping/looping ticks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Metronome settings are now applied correctly when playback starts.
  * Changes to metronome settings continue to take effect during active playback.
  * Improved audio and metronome playback cleanup to prevent interruptions from affecting newer sounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->