### PR TITLE
fix: keep section prefix after adding marchers in welcome flow

### DIFF
--- a/apps/desktop/src/components/marcher/MarcherForm.tsx
+++ b/apps/desktop/src/components/marcher/MarcherForm.tsx
@@ -113,15 +113,15 @@ const MarcherForm: React.FC<MarcherFormProps> = ({
         setQuantityInput(String(defaultQuantity));
         if (!preserveSection) {
             setSection(defaultSection(t));
+            setDrillPrefix(defaultDrillPrefix);
+            setDrillPrefixTouched(false);
         }
         setName("");
         setYear("");
-        setDrillPrefix(defaultDrillPrefix);
         setDrillOrder(defaultDrillOrder);
         setNotes("");
         setSectionError("");
         setDrillPrefixError("");
-        setDrillPrefixTouched(false);
         setDrillOrderError("");
 
         if (formRef.current) formRef.current.reset();


### PR DESCRIPTION
## What
In the new-show performers step, adding marchers no longer clears the drill prefix when the section is unchanged.

## How
- `MarcherForm.resetForm` only resets prefix (and prefix-touched) when section is not preserved, matching wizard mode’s existing section keep behavior