### PR TITLE
Use page number offset when uploading to mobile

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
     "name": "@openmarch/desktop",
     "productName": "OpenMarch",
     "description": "Free drill-writing software for the marching arts",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "main": "dist-electron/main/index.js",
     "author": "OpenMarch LLC <contact@openmarch.com>",
     "url": "https://openmarch.com",

--- a/apps/desktop/src/components/mobile/utilities/__test__/dots-to-om.test.ts
+++ b/apps/desktop/src/components/mobile/utilities/__test__/dots-to-om.test.ts
@@ -148,6 +148,23 @@ describeDbTests("dots-to-om", (it) => {
         expect(result.metadata.audioOffsetSeconds).toBe(1.25);
     });
 
+    it("applies pageNumberOffset from workspace settings to page names", async ({
+        db,
+        marchersAndPages,
+    }) => {
+        const pageNumberOffset = 12;
+        const settings = workspaceSettingsSchema.parse({ pageNumberOffset });
+        await updateWorkspaceSettingsParsed({ db, settings });
+
+        const result = await toOpenMarchSchema(db as unknown as DB);
+        const expectedNames = generatePageNames(
+            result.pages.map((p) => p.isSubset === true),
+            pageNumberOffset,
+        );
+
+        expect(result.pages.map((p) => p.name)).toEqual(expectedNames);
+    });
+
     it("includes performerAppearance with default from field properties", async ({
         db,
     }) => {

--- a/apps/desktop/src/components/mobile/utilities/dots-to-om.ts
+++ b/apps/desktop/src/components/mobile/utilities/dots-to-om.ts
@@ -97,9 +97,11 @@ function getFieldExtentsSteps(fieldProperties: FieldProperties) {
 function buildPagesFromTiming({
     timingRows,
     pagesById,
+    pageNumberOffset = 0,
 }: {
     timingRows: TimingRow[];
     pagesById: Map<number, PageRow>;
+    pageNumberOffset?: number;
 }): {
     id: string;
     duration: number;
@@ -114,7 +116,7 @@ function buildPagesFromTiming({
         pageTimingRows.map(
             (row) => (pagesById.get(row.page_id)?.is_subset ?? 0) === 1,
         ),
-        0,
+        pageNumberOffset,
     );
     return pageTimingRows.map((row, idx) => {
         const startPosition = row.position;
@@ -309,16 +311,20 @@ function buildOpenMarchFromRows(
         getFieldExtentsSteps(fieldProps);
     const centerXPixels = (fieldWidthSteps / 2) * pixelsPerStep;
 
+    const workspaceSettings = workspaceSettingsRow
+        ? workspaceSettingsSchema.parse(
+              JSON.parse(workspaceSettingsRow.json_data),
+          )
+        : undefined;
+
     const metadata = {
         performanceArea,
         createdAtUtc:
             timingRows.length > 0
                 ? new Date(timingRows[0].timestamp * 1000).toISOString()
                 : new Date().toISOString(),
-        ...(workspaceSettingsRow && {
-            audioOffsetSeconds: workspaceSettingsSchema.parse(
-                JSON.parse(workspaceSettingsRow.json_data),
-            ).audioOffsetSeconds,
+        ...(workspaceSettings && {
+            audioOffsetSeconds: workspaceSettings.audioOffsetSeconds,
         }),
     };
 
@@ -335,7 +341,11 @@ function buildOpenMarchFromRows(
         measuresRows.map((m: MeasureRow) => [m.id, m]),
     );
 
-    const pages = buildPagesFromTiming({ timingRows, pagesById });
+    const pages = buildPagesFromTiming({
+        timingRows,
+        pagesById,
+        pageNumberOffset: workspaceSettings?.pageNumberOffset ?? 0,
+    });
     const tempoSections = buildTempoSections(timingRows);
     const coordinates = buildCoordinates({
         marcherPagesRows,


### PR DESCRIPTION
## What
Fixes #1019. Mobile uploads ignored workspace `pageNumberOffset`, so set numbers always started at 0 instead of matching the desktop show.

## How
- Read `pageNumberOffset` from workspace settings in `dots-to-om.ts` and pass it to `buildPagesFromTiming`
- Add unit test covering offset application to exported page names

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Page numbers in converted OpenMarch projects now respect the workspace’s configured page-number offset.
  * Audio timing and page numbering consistently use workspace settings during conversion.

* **Tests**
  * Added coverage verifying custom page-number offsets are applied correctly.

* **Chores**
  * Updated the desktop app version to 0.1.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->