### PR TITLE
fix: use ASCII hyphen in measure ranges for PDF fonts

### DIFF
--- a/apps/desktop/src/global/classes/Page.utils.ts
+++ b/apps/desktop/src/global/classes/Page.utils.ts
@@ -42,7 +42,7 @@ export const measureRangeString = (
                 : `${lastMeasure.number}(${beatToEndOn})`;
 
         if (firstMeasureString === lastMeasureString) return firstMeasureString;
-        return `${firstMeasureString} → ${lastMeasureString}`;
+        return `${firstMeasureString} - ${lastMeasureString}`;
     } catch (err) {
         return "N/A";
     }

--- a/apps/desktop/src/global/classes/__test__/Page.test.ts
+++ b/apps/desktop/src/global/classes/__test__/Page.test.ts
@@ -1152,7 +1152,7 @@ describe("Page", () => {
                         measureBeatToStartOn: 1,
                         measureBeatToEndOn: 4,
                     },
-                    expectedString: "1 → 6",
+                    expectedString: "1 - 6",
                 },
                 {
                     testDescription: "last measure is different counts",
@@ -1166,7 +1166,7 @@ describe("Page", () => {
                         measureBeatToStartOn: 1,
                         measureBeatToEndOn: 3,
                     },
-                    expectedString: "1 → 7",
+                    expectedString: "1 - 7",
                 },
                 {
                     testDescription: "last measure is not a sequential number",
@@ -1180,7 +1180,7 @@ describe("Page", () => {
                         measureBeatToStartOn: 1,
                         measureBeatToEndOn: 3,
                     },
-                    expectedString: "1 → 5000",
+                    expectedString: "1 - 5000",
                 },
                 {
                     testDescription: "not ending on the last beat",
@@ -1191,7 +1191,7 @@ describe("Page", () => {
                         measureBeatToStartOn: 1,
                         measureBeatToEndOn: 3,
                     },
-                    expectedString: "1 → 6(3)",
+                    expectedString: "1 - 6(3)",
                 },
                 {
                     testDescription: "ending on the first beat",
@@ -1202,7 +1202,7 @@ describe("Page", () => {
                         measureBeatToStartOn: 1,
                         measureBeatToEndOn: 1,
                     },
-                    expectedString: "1 → 6(1)",
+                    expectedString: "1 - 6(1)",
                 },
                 {
                     testDescription: "not starting on the first beat",
@@ -1213,7 +1213,7 @@ describe("Page", () => {
                         measureBeatToStartOn: 3,
                         measureBeatToEndOn: 4,
                     },
-                    expectedString: "1(3) → 6",
+                    expectedString: "1(3) - 6",
                 },
                 {
                     testDescription: "starting on the last beat",
@@ -1224,7 +1224,7 @@ describe("Page", () => {
                         measureBeatToStartOn: 4,
                         measureBeatToEndOn: 4,
                     },
-                    expectedString: "1(4) → 6",
+                    expectedString: "1(4) - 6",
                 },
                 {
                     testDescription: "both measures",
@@ -1235,7 +1235,7 @@ describe("Page", () => {
                         measureBeatToStartOn: 2,
                         measureBeatToEndOn: 3,
                     },
-                    expectedString: "1(2) → 6(3)",
+                    expectedString: "1(2) - 6(3)",
                 },
                 {
                     testDescription: "playing in the same measure",
@@ -1253,7 +1253,7 @@ describe("Page", () => {
                         measureBeatToStartOn: 2,
                         measureBeatToEndOn: 4,
                     },
-                    expectedString: "1(2) → 1",
+                    expectedString: "1(2) - 1",
                 },
                 {
                     testDescription: "playing in the same measure pull forward",
@@ -1262,7 +1262,7 @@ describe("Page", () => {
                         measureBeatToStartOn: 1,
                         measureBeatToEndOn: 2,
                     },
-                    expectedString: "1 → 1(2)",
+                    expectedString: "1 - 1(2)",
                 },
                 {
                     testDescription: "playing in the same measure in between",
@@ -1271,7 +1271,7 @@ describe("Page", () => {
                         measureBeatToStartOn: 2,
                         measureBeatToEndOn: 3,
                     },
-                    expectedString: "1(2) → 1(3)",
+                    expectedString: "1(2) - 1(3)",
                 },
             ])("%# - $testDescription", ({ pageObject, expectedString }) => {
                 const result = measureRangeString(pageObject);


### PR DESCRIPTION
fix #1024
## What
Fixes garbled measure-range separators on PDF export (#1024) by replacing the Unicode arrow with an ASCII hyphen.

## How
- `measureRangeString` in `Page.utils.ts` now joins ranges with ` - ` instead of ` → `


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated measure range formatting to use a hyphen instead of an arrow between the first and last measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->